### PR TITLE
[FRCV-45] Remove welcome message from the BE side

### DIFF
--- a/src/containers/namespaces/events/start-chat.ts
+++ b/src/containers/namespaces/events/start-chat.ts
@@ -1,11 +1,5 @@
 import { NamespaceEvent } from '@/services/SocketServer';
 
-const WELCOME_MESSAGE = [
-   `Welcome to the Felipe's CV chat!`,
-   `I'm Felipe's AI assistant and I will assist you with any questions or information you need regarding my CV.`,
-   `Feel free to ask anything about his career and experiences.`
-].join('\n');
-
 const startChatEvent: NamespaceEvent = {
    name: 'start-chat',
    handler(socket, data, callback) {
@@ -31,14 +25,7 @@ const startChatEvent: NamespaceEvent = {
             });
          },
          onJoin: (room, client) => {
-            callback({ success: true });
-
-            this.sendToRoom(room.id, 'assistant-message', {
-               success: true,
-               room: room.id,
-               timestamp: Date.now(),
-               content: WELCOME_MESSAGE
-            });
+            callback({ success: true, room: room.id });
          }
       });
    }


### PR DESCRIPTION
## [FRCV-45] Description
This pull request modifies the `start-chat` event handler in `src/containers/namespaces/events/start-chat.ts` to simplify the functionality and remove the predefined welcome message. The changes streamline the event handling logic and adjust the callback response.

### Simplification of event handling:

* Removed the `WELCOME_MESSAGE` constant, which previously provided a predefined message for new chat participants.
* Updated the `onJoin` handler to no longer send an assistant message with the welcome content to the room. The callback now only returns a success status and the room ID.

[FRCV-45]: https://feliperamosdev.atlassian.net/browse/FRCV-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ