### PR TITLE
[FRCV-54] Campany/Skill Schema and Tables

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,6 +1,8 @@
 import { PostgresDB } from '../services';
 import { AdminUser } from './models/users_schema';
+import companies_schema from './schemas/companies_schema';
 import experiences_schema from './schemas/experiences_schema';
+import skills_schema from './schemas/skills_schema';
 import users_schema from './schemas/users_schema';
 
 const database = new PostgresDB({
@@ -11,7 +13,9 @@ const database = new PostgresDB({
    password: process.env.DB_PASSWORD,
    schemas: [
       users_schema,
-      experiences_schema
+      experiences_schema,
+      companies_schema,
+      skills_schema
    ]
 });
 

--- a/src/database/schemas/companies_schema.ts
+++ b/src/database/schemas/companies_schema.ts
@@ -1,0 +1,8 @@
+import Schema from '../../services/Database/models/Schema';
+import companies from '../tables/companies_schema/companies';
+import company_sets from '../tables/companies_schema/company_sets';
+
+export default new Schema({
+   name: 'companies_schema',
+   tables: [ companies, company_sets ]
+});

--- a/src/database/schemas/skills_schema.ts
+++ b/src/database/schemas/skills_schema.ts
@@ -1,0 +1,7 @@
+import Schema from '../../services/Database/models/Schema';
+import skills from '../tables/skills_schema/skills';
+
+export default new Schema({
+   name: 'skills_schema',
+   tables: [ skills ]
+});

--- a/src/database/tables/companies_schema/companies.ts
+++ b/src/database/tables/companies_schema/companies.ts
@@ -1,0 +1,13 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'companies',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'name', type: 'VARCHAR(255)', notNull: true },
+      { name: 'location', type: 'VARCHAR(255)', notNull: true },
+      { name: 'site_url', type: 'VARCHAR(255)' },
+      { name: 'logo_url', type: 'VARCHAR(255)' },
+   ]
+});

--- a/src/database/tables/companies_schema/company_sets.ts
+++ b/src/database/tables/companies_schema/company_sets.ts
@@ -1,25 +1,20 @@
 import Table from '../../../services/Database/models/Table';
 
 export default new Table({
-   name: 'experience_sets',
+   name: 'companie_sets',
    fields: [
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
-      { name: 'slug', type: 'VARCHAR(255)', notNull: true },
-      { name: 'position', type: 'VARCHAR(255)', notNull: true },
       { name: 'language_set', type: 'VARCHAR(255)', notNull: true },
-      { name: 'summary', type: 'TEXT', notNull: true },
       { name: 'description', type: 'TEXT' },
-      { name: 'responsibilities', type: 'TEXT' },
-      {
-         name: 'experience_id',
+      { name: 'company_id',
          type: 'INTEGER',
          notNull: true,
          relatedField: {
-            schema: 'experiences_schema',
-            table: 'experiences',
+            schema: 'companies_schema',
+            table: 'companies',
             field: 'id'
          }
-      }
+      },
    ]
 });

--- a/src/database/tables/skills_schema/skills.ts
+++ b/src/database/tables/skills_schema/skills.ts
@@ -1,0 +1,11 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'skills',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'name', type: 'VARCHAR(255)', notNull: true },
+      { name: 'category', type: 'VARCHAR(255)', notNull: true }
+   ]
+});


### PR DESCRIPTION
## [FRCV-54] Description
This pull request introduces two new database schemas (`companies_schema` and `skills_schema`) and their associated tables, updates the database initialization to include these schemas, and fixes a typo in an existing table definition. Below is a summary of the most important changes:

### New Database Schemas and Tables:

* **`companies_schema`**:
  - Added a new schema (`companies_schema`) with two tables: `companies` and `company_sets`. The `companies` table includes fields such as `id`, `name`, `location`, `site_url`, and `logo_url`. The `company_sets` table includes fields like `id`, `language_set`, `description`, and a foreign key (`company_id`) referencing the `companies` table. [[1]](diffhunk://#diff-2a15f80d636babe8bcef41ac20f175e3c8b825d9dece86e1757c8d40adaad5d1R1-R8) [[2]](diffhunk://#diff-868ea54a45f40d733f9be5305f78caccc1d86091a5f0a5f3bf35df64a7d5ca9fR1-R13) [[3]](diffhunk://#diff-f7147493fb35b2f86f359a068fbbbfd18a33cc167871c51e53b5e981960d9f58R1-R20)

* **`skills_schema`**:
  - Added a new schema (`skills_schema`) with a single table, `skills`, which includes fields such as `id`, `name`, and `category`. [[1]](diffhunk://#diff-4300131f3519ff2cf519c4f2c4305d948b500346d89a4fadeb807957c7d6f9d2R1-R7) [[2]](diffhunk://#diff-5a82374d7a3d5e5769b6882603a043a8834129c32861a73b115821e253cb6701R1-R11)

### Database Initialization Update:

* Updated the `PostgresDB` initialization in `src/database/index.ts` to include the newly added `companies_schema` and `skills_schema`. [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R3-R5) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352L14-R18)

### Bug Fix:

* Corrected a typo in the `experience_sets` table definition by renaming the field `responsabilities` to `responsibilities`.

[FRCV-54]: https://feliperamosdev.atlassian.net/browse/FRCV-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ