### PR TITLE
[FRCV-58] Endpoint /skill/create

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -7,6 +7,7 @@ import healthRoute from '../routes/health.route';
 import authUserRoute from '../routes/auth/user.route';
 import experienceCreate from '../routes/experience/create';
 import experienceQuery from '../routes/experience/query';
+import skillCreate from '../routes/skill/create';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : undefined;
@@ -42,7 +43,8 @@ export default new ServerAPI({
       authUserRoute,
       healthRoute,
       experienceCreate,
-      experienceQuery
+      experienceQuery,
+      skillCreate
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -1,18 +1,48 @@
-import TableRow from '@/services/Database/models/TableRow';
 import { SkillSetup } from './Skill.types';
+import database from '../../../../database';
+import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
+import SkillSet from '../SkillSet/SkillSet';
 
-export default class Skill extends TableRow {
+export default class Skill extends SkillSet {
    public name: string;
-   public level?: 'beginner' | 'intermediate' | 'advanced';
-   public description?: string;
+   public category: string;
+   public level: number;
 
    constructor (setup: SkillSetup) {
-      super('skills_schema', 'skills', setup);
+      super(setup);
 
-      const { name, level, description } = setup || {};
+      const { name, level, category } = setup || {};
 
       this.name = name;
       this.level = level;
-      this.description = description;
+      this.category = category;
+   }
+
+   static async create(skillData: SkillSetup): Promise<Skill> {
+      try {
+         const { data = [], error } = await database.insert('skills_schema', 'skills').data({
+            name: skillData.name,
+            category: skillData.category,
+            level: skillData.level,
+         }).returning().exec();
+         const [ createdSkill ] = data;
+
+         if (error) {
+            throw new ErrorDatabase(`Database error caught!`, 'DATABASE_ERROR');
+         }
+
+         if (!createdSkill) {
+            throw new ErrorDatabase(`Skill creation failed!`, 'SKILL_CREATION_FAILED');
+         }
+
+         const skillSetCreated = await this.set({
+            skill_id: createdSkill.id,
+            journey: skillData.journey
+         });
+
+         return new Skill({ ...createdSkill, ...skillSetCreated });
+      } catch (error) {
+         throw error;
+      }
    }
 }

--- a/src/database/models/skills_schema/Skill/Skill.types.ts
+++ b/src/database/models/skills_schema/Skill/Skill.types.ts
@@ -1,5 +1,7 @@
-export interface SkillSetup {
+import { SkillSetSetup } from "../SkillSet/SkillSet.types";
+
+export interface SkillSetup extends SkillSetSetup {
    name: string;
-   level?: 'beginner' | 'intermediate' | 'advanced';
-   description?: string;
+   level: number;
+   category: string;
 }

--- a/src/database/models/skills_schema/SkillSet/SkillSet.ts
+++ b/src/database/models/skills_schema/SkillSet/SkillSet.ts
@@ -1,0 +1,39 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import database from '../../../../database';
+import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
+import { SkillSetSetup } from './SkillSet.types';
+
+export default class SkillSet extends TableRow {
+   public skill_id: number;
+   public language_set: string;
+   public journey?: string;
+
+   constructor (setup: SkillSetSetup) {
+      super('skills_schema', 'skills', setup);
+
+      const { skill_id, language_set = 'en', journey } = setup || {};
+
+      if (!skill_id) {
+         throw new ErrorDatabase(`SkillSet requires skill_id`, 'SKILL_SET_SETUP_ERROR');
+      }
+
+      this.skill_id = skill_id;
+      this.language_set = language_set;
+      this.journey = journey;
+   }
+
+   static async set(skillSetData: SkillSetSetup): Promise<SkillSet> {
+      try {
+         const { data = [] } = await database.insert('skills_schema', 'skill_sets').data(skillSetData).returning().exec();
+         const [ skillSetCreated ] = data;
+
+         if (!skillSetCreated) {
+            throw new ErrorDatabase(`Skill set creation failed!`, 'SKILL_SET_CREATION_FAILED');
+         }
+
+         return new SkillSet(skillSetCreated);
+      } catch (error) {
+         throw error;
+      }
+   }
+}

--- a/src/database/models/skills_schema/SkillSet/SkillSet.types.ts
+++ b/src/database/models/skills_schema/SkillSet/SkillSet.types.ts
@@ -1,0 +1,5 @@
+export interface SkillSetSetup {
+   skill_id: number;
+   language_set?: string;
+   journey?: string;
+}

--- a/src/database/schemas/skills_schema.ts
+++ b/src/database/schemas/skills_schema.ts
@@ -1,7 +1,8 @@
 import Schema from '../../services/Database/models/Schema';
+import skill_sets from '../tables/skills_schema/skill_sets';
 import skills from '../tables/skills_schema/skills';
 
 export default new Schema({
    name: 'skills_schema',
-   tables: [ skills ]
+   tables: [ skills, skill_sets ]
 });

--- a/src/database/tables/experiences_schema/experience_sets.ts
+++ b/src/database/tables/experiences_schema/experience_sets.ts
@@ -6,7 +6,7 @@ export default new Table({
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'slug', type: 'VARCHAR(255)', notNull: true },
-      { name: 'position', type: 'VARCHAR(20)', notNull: true },
+      { name: 'position', type: 'VARCHAR(50)', notNull: true },
       { name: 'language_set', type: 'VARCHAR(2)', defaultValue: 'en' },
       { name: 'summary', type: 'TEXT', notNull: true },
       { name: 'description', type: 'TEXT' },

--- a/src/database/tables/skills_schema/skill_sets.ts
+++ b/src/database/tables/skills_schema/skill_sets.ts
@@ -1,0 +1,20 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'skill_sets',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: 'en' },
+      { name: 'journey', type: 'VARCHAR(255)' },
+      { name: 'skill_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'skills_schema',
+            table: 'skills',
+            field: 'id'
+         }
+      }
+   ]
+});

--- a/src/database/tables/skills_schema/skills.ts
+++ b/src/database/tables/skills_schema/skills.ts
@@ -6,6 +6,7 @@ export default new Table({
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'name', type: 'VARCHAR(255)', notNull: true },
-      { name: 'category', type: 'VARCHAR(255)', notNull: true }
+      { name: 'category', type: 'VARCHAR(255)', notNull: true },
+      { name: 'level', type: 'INTEGER', notNull: true }
    ]
 });

--- a/src/routes/skill/create.ts
+++ b/src/routes/skill/create.ts
@@ -1,0 +1,22 @@
+import { Skill } from '../../database/models/skills_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Request, Response } from 'express';
+
+export default new Route({
+   method: 'PUT',
+   routePath: '/skill/create',
+   useAuth: true,
+   allowedRoles: ['master', 'admin'],
+   controller: async (req: Request, res: Response): Promise<void> => {
+      const skillData = req.body;
+
+      try {
+         const newSkill = await Skill.create(skillData);
+   
+         res.status(201).send(newSkill);
+      } catch (error) {
+         new ErrorResponseServerAPI().send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-58] Description
This pull request introduces significant updates to the skills management system, including new database models, schema changes, and API routes for creating skills. These changes enhance the system's functionality and structure by introducing a `SkillSet` model, updating the `Skill` model, and adding a new API route for skill creation.

### API Enhancements:
* Added a new API route `PUT /skill/create` to handle skill creation. This route includes authentication, role-based access control, and integrates with the updated `Skill` model to persist data in the database. (`src/routes/skill/create.ts`)
* Registered the new `skillCreate` route in the `ServerAPI` configuration to make it available in the API server. (`src/containers/api-server.service.ts`) [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR10) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL45-R47)

### Database Model Updates:
* Updated the `Skill` model to include a `category` and a numeric `level` field, replacing the previous `description` and string-based `level`. Added a static `create` method to handle skill creation with error handling. (`src/database/models/skills_schema/Skill/Skill.ts`)
* Introduced a new `SkillSet` model to manage additional metadata for skills, such as `language_set` and `journey`. This model includes a static `set` method for creating skill sets. (`src/database/models/skills_schema/SkillSet/SkillSet.ts`)

### Database Schema and Table Changes:
* Updated the `skills` table to include a new `level` column to store skill levels as integers. (`src/database/tables/skills_schema/skills.ts`)
* Added a new `skill_sets` table to store metadata associated with skills, including relationships to the `skills` table. (`src/database/tables/skills_schema/skill_sets.ts`)
* Updated the `skills_schema` to include the new `skill_sets` table. (`src/database/schemas/skills_schema.ts`)

### Type Definitions:
* Updated the `SkillSetup` interface to reflect the changes in the `Skill` model, including the addition of `category` and numeric `level` fields. (`src/database/models/skills_schema/Skill/Skill.types.ts`)
* Added a new `SkillSetSetup` interface to define the structure of data used in the `SkillSet` model. (`src/database/models/skills_schema/SkillSet/SkillSet.types.ts`)

These changes collectively improve the system's ability to manage and organize skills, while also laying the groundwork for more complex relationships and functionality in the future.