### PR TITLE
[FRCV-59] Endpoint /skill/query

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -8,6 +8,7 @@ import authUserRoute from '../routes/auth/user.route';
 import experienceCreate from '../routes/experience/create';
 import experienceQuery from '../routes/experience/query';
 import skillCreate from '../routes/skill/create';
+import skillQuery from '../routes/skill/query';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : undefined;
@@ -44,7 +45,8 @@ export default new ServerAPI({
       healthRoute,
       experienceCreate,
       experienceQuery,
-      skillCreate
+      skillCreate,
+      skillQuery
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -49,7 +49,7 @@ export default class Skill extends SkillSet {
 
    static async getSkillsByUserId(userId: number, language_set: string = 'en'): Promise<Skill[]> {
       try {
-         const query = database.select('skills_schema', 'skill_sets')
+         const query = database.select('skills_schema', 'skill_sets');
          query.where({ user_id: userId, language_set });
          query.populate('skill_id', ['name', 'category', 'level']);
 

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -46,4 +46,21 @@ export default class Skill extends SkillSet {
          throw error;
       }
    }
+
+   static async getSkillsByUserId(userId: number, language_set: string = 'en'): Promise<Skill[]> {
+      try {
+         const query = database.select('skills_schema', 'skill_sets')
+         query.where({ user_id: userId, language_set });
+         query.populate('skill_id', ['name', 'category', 'level']);
+
+         const { data = [], error } = await query.exec();
+         if (error) {
+            throw new ErrorDatabase(`Database error caught!`, 'DATABASE_ERROR');
+         }
+
+         return data.map(skill => new Skill(skill));
+      } catch (error) {
+         throw error;
+      }
+   }
 }

--- a/src/routes/skill/query.ts
+++ b/src/routes/skill/query.ts
@@ -9,7 +9,7 @@ export default new Route({
    useAuth: true,
    allowedRoles: [ 'master', 'admin' ],
    controller: async (req: Request, res: Response): Promise<void> => {
-      const { language_set } = req.body || {};
+      const { language_set } = Object(req.query);
       const userId = req.session.user?.id;
 
       if (!userId) {
@@ -21,7 +21,7 @@ export default new Route({
          const loadedSkills = await Skill.getSkillsByUserId(userId, language_set);
          res.status(200).send(loadedSkills);
       } catch (error) {
-         console.error('Error creating skill:', error);
+         console.error('Error querying skill:', error);
          new ErrorResponseServerAPI().send(res);
       }
    }

--- a/src/routes/skill/query.ts
+++ b/src/routes/skill/query.ts
@@ -1,0 +1,28 @@
+import { Skill } from '../../database/models/skills_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Request, Response } from 'express';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/skill/query',
+   useAuth: true,
+   allowedRoles: [ 'master', 'admin' ],
+   controller: async (req: Request, res: Response): Promise<void> => {
+      const { language_set } = req.body || {};
+      const userId = req.session.user?.id;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User not authenticated', 401, 'USER_NOT_AUTHENTICATED').send(res);
+         return;
+      }
+
+      try {
+         const loadedSkills = await Skill.getSkillsByUserId(userId, language_set);
+         res.status(200).send(loadedSkills);
+      } catch (error) {
+         console.error('Error creating skill:', error);
+         new ErrorResponseServerAPI().send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-59] Description
This pull request introduces a new feature to query skills by user ID and language set. It includes updates to the API server, database model, and routing to support this functionality. The most important changes are categorized below:

### API and Routing Enhancements:
* Added a new route `skillQuery` in `src/routes/skill/query.ts` to handle GET requests for querying skills by user ID and language set. This route includes authentication and role-based access control.
* Updated `src/containers/api-server.service.ts` to import and register the new `skillQuery` route in the API server. [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR11) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL47-R49)

### Database Model Updates:
* Added a static method `getSkillsByUserId` to the `Skill` class in `src/database/models/skills_schema/Skill/Skill.ts`. This method retrieves skills from the database based on the user ID and language set, with error handling and data mapping.

[FRCV-59]: https://feliperamosdev.atlassian.net/browse/FRCV-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ