### PR TITLE
[FRCV-63] Skills population

### DIFF
--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -4,6 +4,7 @@ import database from '../../../../database';
 import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import { AdminUser } from '../../users_schema';
 import { Company } from '../../companies_schema';
+import { Skill } from '../../skills_schema';
 
 export default class Experience extends ExperienceSet {
    public type: ExperienceType;
@@ -100,6 +101,11 @@ export default class Experience extends ExperienceSet {
          // Populating company data for each experience
          for (const exp of data) {
             exp.company = await Company.getById(exp.company_id, language_set);
+
+            // Populate skills data
+            if (Array.isArray(exp.skills) && exp.skills.length) {
+               exp.skills = await Skill.getManyByIds(exp.skills, language_set);
+            }
          }
 
          return data.map(exp => new Experience(exp));

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -63,4 +63,46 @@ export default class Skill extends SkillSet {
          throw error;
       }
    }
+
+   static async getById(skill_id: number, language_set: string = 'en'): Promise<Skill | null> {
+      try {
+         const query = database.select('skills_schema', 'skill_sets');
+
+         query.where({ skill_id, language_set });
+         query.populate('skill_id', ['name', 'category', 'level']);
+
+         const { data = [], error } = await query.exec();
+         const [ dataSkill ] = data;
+         if (error) {
+            throw new ErrorDatabase(`Database error caught!`, 'DATABASE_ERROR');
+         }
+
+         if (!dataSkill) {
+            return null;
+         }
+
+         return new Skill(dataSkill);
+      } catch (error) {
+         throw error;
+      }
+   }
+
+   static async getManyByIds(skillIds: number[], language_set: string = 'en'): Promise<Skill[]> {
+      try {
+         const query = database.select('skills_schema', 'skill_sets');
+         const skillIdsSet = skillIds.map(id => ({ skill_id: id, language_set }));
+
+         query.where(skillIdsSet);
+         query.populate('skill_id', ['name', 'category', 'level']);
+
+         const { data = [], error } = await query.exec();
+         if (error) {
+            throw new ErrorDatabase(`Database error caught!`, 'DATABASE_ERROR');
+         }
+
+         return data.map(skill => new Skill(skill));
+      } catch (error) {
+         throw error;
+      }
+   }
 }


### PR DESCRIPTION
## [FRCV-63] Description
This pull request introduces functionality to populate skill data for experiences in the `Experience` model and adds new utility methods to the `Skill` model for fetching skill data from the database. The most important changes include importing the `Skill` model, updating the `Experience` model to populate skills, and adding new static methods in the `Skill` model to fetch single or multiple skills by ID.

### Updates to `Experience` model:

* Added import for the `Skill` model in `Experience.ts` to enable skill-related operations.
* Updated the `Experience` class to populate skill data for each experience by calling the new `Skill.getManyByIds` method when skill IDs are present.

### Enhancements to `Skill` model:

* Added a new static method `getById` in `Skill.ts` to fetch a single skill by its ID and language set. This method queries the database and returns a `Skill` instance or `null` if the skill is not found.
* Added a new static method `getManyByIds` in `Skill.ts` to fetch multiple skills by their IDs and language set. This method returns an array of `Skill` instances.

[FRCV-63]: https://feliperamosdev.atlassian.net/browse/FRCV-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ