### PR TITLE
[FRCV-64] Route /experience/:experience_id

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -7,6 +7,7 @@ import healthRoute from '../routes/health.route';
 import authUserRoute from '../routes/auth/user.route';
 import experienceCreate from '../routes/experience/create';
 import experienceQuery from '../routes/experience/query';
+import experienceGet from '../routes/experience/experience_id';
 import skillCreate from '../routes/skill/create';
 import skillQuery from '../routes/skill/query';
 import companyCreate from '../routes/company/create';
@@ -50,7 +51,8 @@ export default new ServerAPI({
       skillCreate,
       skillQuery,
       companyCreate,
-      companyQuery
+      companyQuery,
+      experienceGet
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/companies_schema/CompanySet/CompanySet.ts
+++ b/src/database/models/companies_schema/CompanySet/CompanySet.ts
@@ -6,8 +6,8 @@ import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 export default class CompanySet extends TableRow {
    public description: string;
    public industry: string;
-   public user_id: number;
-   public company_id: number;
+   public user_id?: number;
+   public company_id?: number;
 
    constructor (setup: CompanySetSetup, schemaName: string = 'companies_schema', tableName: string = 'company_sets') {
       super(schemaName, tableName, setup);
@@ -18,10 +18,6 @@ export default class CompanySet extends TableRow {
          description = '',
          industry = ''
       } = setup || {};
-
-      if (!company_id || !user_id) {
-         throw new ErrorDatabase('Company ID and User ID are required to create a company set.', 'COMPANY_SET_CREATION_ERROR');
-      }
 
       this.company_id = company_id;
       this.user_id = user_id;

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -5,6 +5,7 @@ import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import { AdminUser } from '../../users_schema';
 import { Company } from '../../companies_schema';
 import { Skill } from '../../skills_schema';
+import { ExperienceSetSetup } from '../ExperienceSet/ExperienceSet.types';
 
 export default class Experience extends ExperienceSet {
    public type: ExperienceType;
@@ -15,7 +16,8 @@ export default class Experience extends ExperienceSet {
    public company_id: number;
    public company?: Company;
    public skills: number[];
-   public user: AdminUser;
+   public user?: AdminUser;
+   public languageSets: ExperienceSet[];
 
    constructor(setup: ExperienceSetup) {
       super(setup, 'experiences_schema', 'experiences');
@@ -32,7 +34,9 @@ export default class Experience extends ExperienceSet {
          end_date,
          company_id,
          company,
-         skills = []
+         skills = [],
+         languageSets = [],
+         user_id
       } = setup;
 
       this.type = type;
@@ -43,8 +47,11 @@ export default class Experience extends ExperienceSet {
       this.company_id = company_id;
       this.company = company ? new Company(company) : undefined;
       this.skills = skills;
+      this.languageSets = languageSets.map((xpSet: ExperienceSetSetup) => new ExperienceSet(xpSet));
 
-      this.user = new AdminUser({ ...setup, id: setup.user_id, created_at: undefined });
+      if (user_id) {
+         this.user = new AdminUser({ ...setup, id: user_id, created_at: undefined });
+      }
    }
 
    static async create(data: ExperienceCreateSetup): Promise<Experience> {
@@ -79,6 +86,35 @@ export default class Experience extends ExperienceSet {
          return new Experience({ ...createdExperience, ...createdDefaultSet });
       } catch (error: any) {
          throw new ErrorDatabase('Failed to create Experience: ' + error.message, 'EXPERIENCE_CREATION_ERROR');
+      }
+   }
+
+   static async getFullSet(experienceId: number): Promise<Experience | null> {
+      try {
+         const expBaseQuery = database.select('experiences_schema', 'experiences');
+         expBaseQuery.where({ 'experiences.id': experienceId });
+         expBaseQuery.populate('company_id', [ 'company_name', 'logo_url', 'site_url', 'location' ]);
+
+         const { data = [], error } = await expBaseQuery.exec();
+         const [ experienceData ] = data;
+
+         if (error || !experienceData) {
+            throw new ErrorDatabase('Experience not found', 'EXPERIENCE_NOT_FOUND');
+         }
+
+         const experienceSetQuery = database.select('experiences_schema', 'experience_sets');
+         experienceSetQuery.where({ experience_id: experienceId });
+
+         const { data: experienceSetData = [] } = await experienceSetQuery.exec();
+         const company = new Company(experienceData);
+
+         experienceData.company = company;
+         experienceData.languageSets = experienceSetData;
+         experienceData.skills = await Skill.getManyByIds(experienceData.skills);
+
+         return new Experience(experienceData);
+      } catch (error) {
+         throw error;
       }
    }
 

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -113,8 +113,8 @@ export default class Experience extends ExperienceSet {
          experienceData.skills = await Skill.getManyByIds(experienceData.skills);
 
          return new Experience(experienceData);
-      } catch (error) {
-         throw error;
+      } catch (error: any) {
+         throw new ErrorDatabase('Failed to fetch Experience: ' + error.message, 'EXPERIENCE_QUERY_ERROR');
       }
    }
 

--- a/src/database/models/experiences_schema/Experience/Experience.types.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.types.ts
@@ -15,6 +15,7 @@ export interface ExperienceSetup extends ExperienceSetSetup {
    company?: Company;
    user?: AdminUser;
    skills: number[];
+   languageSets?: ExperienceSetSetup[];
 }
 
 export interface ExperienceCreateSetup {

--- a/src/database/models/experiences_schema/ExperienceSet/ExperienceSet.ts
+++ b/src/database/models/experiences_schema/ExperienceSet/ExperienceSet.ts
@@ -29,10 +29,6 @@ export default class ExperienceSet extends TableRow {
          user_id
       } = setup || {};
 
-      if (user_id === undefined || user_id === null) {
-         throw new ErrorDatabase('user_id is required to create an ExperienceSet instance.');
-      }
-
       this.slug = slug;
       this.position = position;
       this.language_set = language_set;

--- a/src/routes/experience/experience_id.ts
+++ b/src/routes/experience/experience_id.ts
@@ -9,7 +9,12 @@ export default new Route({
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
       const { experience_id } = req.params;
-      const experienceId = Number(experience_id);
+      const experienceId = parseInt(experience_id, 10);
+
+      if (isNaN(experienceId)) {
+         new ErrorResponseServerAPI('Invalid experience ID', 400, 'INVALID_EXPERIENCE_ID').send(res);
+         return;
+      }
 
       try {
          const experience = await Experience.getFullSet(experienceId);
@@ -20,7 +25,7 @@ export default new Route({
 
          res.status(200).send(experience);
       } catch (error) {
-         new ErrorResponseServerAPI('Failed to fetch Experience!', 404, 'EXPERIENCE_QUERY_ERROR').send(res);
+         new ErrorResponseServerAPI('Failed to fetch Experience!', 500, 'EXPERIENCE_QUERY_ERROR').send(res);
       }
    }
 });

--- a/src/routes/experience/experience_id.ts
+++ b/src/routes/experience/experience_id.ts
@@ -1,0 +1,26 @@
+import { Experience } from '../../database/models/experiences_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/experience/:experience_id',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const { experience_id } = req.params;
+      const experienceId = Number(experience_id);
+
+      try {
+         const experience = await Experience.getFullSet(experienceId);
+         if (!experience) {
+            new ErrorResponseServerAPI('Experience not found', 404, 'EXPERIENCE_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(experience);
+      } catch (error) {
+         new ErrorResponseServerAPI('Failed to fetch Experience!', 404, 'EXPERIENCE_QUERY_ERROR').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-64] Description
This pull request introduces a new API endpoint for retrieving detailed experience data, along with updates to the database models to support optional fields and additional functionality. The most important changes include adding the `/experience/:experience_id` route, implementing the `getFullSet` method in the `Experience` class, and modifying related database models to handle optional fields and nested data.

### API Enhancements:
* Added a new route `/experience/:experience_id` in `src/routes/experience/experience_id.ts` to fetch detailed experience data, including associated company, skills, and language sets. The route supports authentication and role-based access.
* Registered the new `experienceGet` route in the `ServerAPI` configuration in `src/containers/api-server.service.ts`. [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR10) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL53-R55)

### Database Model Updates:
* Introduced a `getFullSet` static method in the `Experience` class to retrieve comprehensive experience data, including nested relationships such as `languageSets` and `skills`.
* Updated the `Experience` class to include a new `languageSets` property and modified the constructor to handle optional `user` and `languageSets` fields. [[1]](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L18-R20) [[2]](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L35-R39) [[3]](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390R50-R54)
* Modified the `ExperienceSetup` interface to include an optional `languageSets` property.

### Validation Relaxation:
* Removed validation for mandatory `user_id` and `company_id` fields in the `CompanySet` class, making them optional. [[1]](diffhunk://#diff-e23de698288400ee0554d1694daf2a4d38f078233e2449b5cc6c04a6a0312076L9-R10) [[2]](diffhunk://#diff-e23de698288400ee0554d1694daf2a4d38f078233e2449b5cc6c04a6a0312076L22-L25)
* Removed validation for the `user_id` field in the `ExperienceSet` class, allowing it to be optional.

[FRCV-64]: https://feliperamosdev.atlassian.net/browse/FRCV-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ