### PR TITLE
[FRCV-67] Route /experience/create-set

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -6,6 +6,7 @@ import loginRoute from '../routes/auth/login.route';
 import healthRoute from '../routes/health.route';
 import authUserRoute from '../routes/auth/user.route';
 import experienceCreate from '../routes/experience/create';
+import experienceCreateSet from '../routes/experience/create-set';
 import experienceQuery from '../routes/experience/query';
 import experienceUpdate from '../routes/experience/update';
 import experienceUpdateSet from '../routes/experience/update-set';
@@ -49,14 +50,15 @@ export default new ServerAPI({
       authUserRoute,
       healthRoute,
       experienceCreate,
+      experienceCreateSet,
       experienceQuery,
+      experienceGet,
+      experienceUpdate,
+      experienceUpdateSet,
       skillCreate,
       skillQuery,
       companyCreate,
       companyQuery,
-      experienceGet,
-      experienceUpdate,
-      experienceUpdateSet
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/routes/experience/create-set.ts
+++ b/src/routes/experience/create-set.ts
@@ -1,0 +1,28 @@
+import database from '../../database';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/experience/create-set',
+   useAuth: true,
+   allowedRoles: [ 'master', 'admin' ],
+   controller: async (req, res) => {
+      const userId = req.session.user?.id;
+      const dataSet = Object(req.body);
+
+      try {
+         const { data = [], error } = await database.insert('experiences_schema', 'experience_sets').data({ ...dataSet, user_id: userId }).returning().exec();
+         const [ created ] = data;
+
+         if (!created || error) {
+            new ErrorResponseServerAPI('Failed to create experience set', 400, 'CREATE_EXPERIENCE_SET').send(res);
+         }
+
+         res.status(201).send(created);
+      } catch (error) {
+         console.error('Error creating experience set:', error);
+         new ErrorResponseServerAPI('Failed to create experience set', 500, 'CREATE_EXPERIENCE_SET').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-67] Description
This pull request introduces a new feature for creating experience sets via the API and includes related updates to the server configuration and routing. The most important changes involve adding a new route for creating experience sets, updating the API server to include this route, and implementing the route's functionality.

### New Feature: Experience Set Creation

* **New route for creating experience sets**: Added `experienceCreateSet` route in `src/routes/experience/create-set.ts`. This route allows authenticated users with `master` or `admin` roles to create experience sets in the database. It handles errors gracefully and returns the created record on success.

### API Server Updates

* **Route import**: Added `experienceCreateSet` to the imports in `src/containers/api-server.service.ts`.
* **Route registration**: Registered the new `experienceCreateSet` route in the `ServerAPI` configuration within `src/containers/api-server.service.ts`.

[FRCV-67]: https://feliperamosdev.atlassian.net/browse/FRCV-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ