### PR TITLE
[FRCV-69] Routes to edit and read Skills

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -2,17 +2,26 @@ import 'dotenv/config';
 
 import '../database';
 import ServerAPI from '../services/ServerAPI/ServerAPI';
-import loginRoute from '../routes/auth/login.route';
+
 import healthRoute from '../routes/health.route';
+
+import loginRoute from '../routes/auth/login.route';
 import authUserRoute from '../routes/auth/user.route';
+
 import experienceCreate from '../routes/experience/create';
 import experienceCreateSet from '../routes/experience/create-set';
 import experienceQuery from '../routes/experience/query';
 import experienceUpdate from '../routes/experience/update';
 import experienceUpdateSet from '../routes/experience/update-set';
 import experienceGet from '../routes/experience/experience_id';
+
 import skillCreate from '../routes/skill/create';
+import skillCreateSet from '../routes/skill/create-set';
 import skillQuery from '../routes/skill/query';
+import skillGet from '../routes/skill/skill_id';
+import skillUpdate from '../routes/skill/update';
+import skillUpdateSet from '../routes/skill/update-set';
+
 import companyCreate from '../routes/company/create';
 import companyCreateSet from '../routes/company/create-set';
 import companyQuery from '../routes/company/query';
@@ -60,7 +69,11 @@ export default new ServerAPI({
       experienceUpdate,
       experienceUpdateSet,
       skillCreate,
+      skillCreateSet,
       skillQuery,
+      skillGet,
+      skillUpdate,
+      skillUpdateSet,
       companyCreate,
       companyCreateSet,
       companyUpdate,

--- a/src/database/models/skills_schema/Skill/Skill.types.ts
+++ b/src/database/models/skills_schema/Skill/Skill.types.ts
@@ -7,13 +7,14 @@ export interface SkillCreateSetup {
    skill_id?: number;
    language_set?: string;
    journey?: string;
-   user_id?: number; 
+   user_id?: number;
 }
 
 export interface SkillSetup extends SkillSetSetup {
    name: string;
    level: number;
    category: string;
+   languageSets?: SkillSetSetup[];
 }
 
 // export interface SkillCreateSetup extends SkillSetup {}

--- a/src/database/models/skills_schema/SkillSet/SkillSet.ts
+++ b/src/database/models/skills_schema/SkillSet/SkillSet.ts
@@ -14,10 +14,6 @@ export default class SkillSet extends TableRow {
 
       const { user_id, skill_id, language_set = 'en', journey } = setup || {};
 
-      if (!skill_id) {
-         throw new ErrorDatabase(`SkillSet requires skill_id`, 'SKILL_SET_SETUP_ERROR');
-      }
-
       this.skill_id = skill_id;
       this.language_set = language_set;
       this.journey = journey;
@@ -36,6 +32,27 @@ export default class SkillSet extends TableRow {
          return new SkillSet(skillSetCreated);
       } catch (error) {
          throw error;
+      }
+   }
+
+   static async updateSet(id: number, updates: Partial<SkillSetSetup>): Promise<SkillSet | null> {
+      try {
+         const query = database.update('skills_schema', 'skill_sets');
+
+         query.set(updates);
+         query.where({ id });
+         query.returning();
+
+         const { data = [] } = await query.exec();
+         const [ updatedSkillSet ] = data;
+
+         if (!updatedSkillSet) {
+            return null;
+         }
+
+         return new SkillSet(updatedSkillSet);
+      } catch (error) {
+         throw new ErrorDatabase(`Skill set update failed!`, 'SKILL_SET_UPDATE_FAILED');
       }
    }
 }

--- a/src/routes/skill/create-set.ts
+++ b/src/routes/skill/create-set.ts
@@ -1,0 +1,33 @@
+import SkillSet from '../../database/models/skills_schema/SkillSet/SkillSet';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/skill/create-set',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const skillData = req.body;
+      const userId = req.session.user?.id;
+
+      if (!skillData) {
+         new ErrorResponseServerAPI('Invalid request data', 400, 'INVALID_REQUEST_DATA').send(res);
+         return;
+      }
+
+      try {
+         const newSkillSet = await SkillSet.set({ ...skillData, user_id: userId });
+
+         if (!newSkillSet) {
+            new ErrorResponseServerAPI('Skill set creation failed', 500, 'SKILL_SET_CREATION_FAILED').send(res);
+            return;
+         }
+
+         res.status(201).send(newSkillSet);
+      } catch (error) {
+         console.error('Error creating skill set:', error);
+         new ErrorResponseServerAPI('Error creating skill set', 500, 'SKILL_SET_CREATION_FAILED').send(res);
+      }
+   }
+});

--- a/src/routes/skill/skill_id.ts
+++ b/src/routes/skill/skill_id.ts
@@ -10,20 +10,20 @@ export default new Route({
       const { skill_id } = req.params;
       const skillId = Number(skill_id);
 
-      if (!skillId) {
+      if (isNaN(skillId) || skillId < 0) {
          new ErrorResponseServerAPI('Skill ID is required', 400, 'SKILL_ID_REQUIRED').send(res);
          return;
       }
 
       try {
-         const skill = await Skill.getFullSet(Number(skillId));
+         const skill = await Skill.getFullSet(skillId);
          
          if (!skill) {
             new ErrorResponseServerAPI('Skill not found', 404, 'SKILL_NOT_FOUND').send(res);
             return;
          }
 
-         res.status(200).send(skill)
+         res.status(200).send(skill);
       } catch (error) {
          console.error("Error in skill details route:", error);
          new ErrorResponseServerAPI('Internal Server Error', 500, '').send(res);

--- a/src/routes/skill/skill_id.ts
+++ b/src/routes/skill/skill_id.ts
@@ -1,0 +1,32 @@
+import { Skill } from '../../database/models/skills_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Request, Response } from 'express';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/skill/:skill_id',
+   controller: async (req: Request, res: Response) => {
+      const { skill_id } = req.params;
+      const skillId = Number(skill_id);
+
+      if (!skillId) {
+         new ErrorResponseServerAPI('Skill ID is required', 400, 'SKILL_ID_REQUIRED').send(res);
+         return;
+      }
+
+      try {
+         const skill = await Skill.getFullSet(Number(skillId));
+         
+         if (!skill) {
+            new ErrorResponseServerAPI('Skill not found', 404, 'SKILL_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(skill)
+      } catch (error) {
+         console.error("Error in skill details route:", error);
+         new ErrorResponseServerAPI('Internal Server Error', 500, '').send(res);
+      }
+   }
+});

--- a/src/routes/skill/update-set.ts
+++ b/src/routes/skill/update-set.ts
@@ -27,7 +27,7 @@ export default new Route({
          res.status(200).send({ message: 'Skill set updated successfully' });
       } catch (error) {
          console.error('Error updating skill set:', error);
-         new ErrorResponseServerAPI('Error updating skill set').send(res);
+         new ErrorResponseServerAPI('Error updating skill set', 500, 'SERVER_ERROR').send(res);
       }
    }
 });

--- a/src/routes/skill/update-set.ts
+++ b/src/routes/skill/update-set.ts
@@ -1,0 +1,33 @@
+import SkillSet from '../../database/models/skills_schema/SkillSet/SkillSet';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Request, Response } from 'express';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/skill/update-set',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req: Request, res: Response) => {
+      const { id, updates } = req.body;
+
+      if (!id || !updates || !Object.keys(updates).length) {
+         new ErrorResponseServerAPI('Invalid request data', 400, 'INVALID_REQUEST_DATA').send(res);
+         return;
+      }
+
+      try {
+         const updatedSkillSet = await SkillSet.updateSet(id, updates);
+
+         if (!updatedSkillSet) {
+            new ErrorResponseServerAPI('Skill set not found or update failed', 404, 'SKILL_SET_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send({ message: 'Skill set updated successfully' });
+      } catch (error) {
+         console.error('Error updating skill set:', error);
+         new ErrorResponseServerAPI('Error updating skill set').send(res);
+      }
+   }
+});

--- a/src/routes/skill/update.ts
+++ b/src/routes/skill/update.ts
@@ -1,0 +1,33 @@
+import Skill from '../../database/models/skills_schema/Skill/Skill';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Request, Response } from 'express';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/skill/update',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req: Request, res: Response) => {
+      const { id, updates } = req.body;
+
+      if (!id || !updates) {
+         new ErrorResponseServerAPI('Skill ID and updates are required.', 400, 'SKILL_ID_UPDATES_REQUIRED').send(res);
+         return;
+      }
+
+      try {
+         const updatedSkill = await Skill.update(id, updates);
+
+         if (!updatedSkill) {
+            new ErrorResponseServerAPI('Skill not found', 404, 'SKILL_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(updatedSkill);
+      } catch (error) {
+         console.error('Error updating skill:', error);
+         new ErrorResponseServerAPI('Error updating skill', 500, 'SKILL_UPDATE').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-69] Description
This pull request introduces several enhancements to the `Skill` and `SkillSet` models, as well as new and updated API routes for managing skills and their associated sets. The changes improve functionality for creating, retrieving, and updating skills and skill sets, while also enhancing the database schema and API structure.

### Enhancements to `Skill` and `SkillSet` models:

* Added a new `languageSets` property to the `Skill` model, allowing skills to include associated language sets. Updated the constructor to handle this property. (`src/database/models/skills_schema/Skill/Skill.ts`, [src/database/models/skills_schema/Skill/Skill.tsR10-R20](diffhunk://#diff-b534653f310c495b6837443bf7cab817dcf9e516d8af6d688d9e1f45996f4d87R10-R20))
* Introduced a static `getFullSet` method in the `Skill` model to retrieve a skill along with its associated language sets from the database. (`src/database/models/skills_schema/Skill/Skill.ts`, [src/database/models/skills_schema/Skill/Skill.tsR110-R155](diffhunk://#diff-b534653f310c495b6837443bf7cab817dcf9e516d8af6d688d9e1f45996f4d87R110-R155))
* Added a static `update` method to the `Skill` model for updating skill records in the database. (`src/database/models/skills_schema/Skill/Skill.ts`, [src/database/models/skills_schema/Skill/Skill.tsR110-R155](diffhunk://#diff-b534653f310c495b6837443bf7cab817dcf9e516d8af6d688d9e1f45996f4d87R110-R155))
* Added a static `updateSet` method to the `SkillSet` model for updating skill set records in the database. (`src/database/models/skills_schema/SkillSet/SkillSet.ts`, [src/database/models/skills_schema/SkillSet/SkillSet.tsR37-R57](diffhunk://#diff-01a6f90964104090936c8bbe03bfe0f1e829e13876f9c0a74e40587f87c056c4R37-R57))

### Database schema updates:

* Updated the `SkillSetup` interface to include an optional `languageSets` property, aligning with the changes in the `Skill` model. (`src/database/models/skills_schema/Skill/Skill.types.ts`, [src/database/models/skills_schema/Skill/Skill.types.tsR17](diffhunk://#diff-bbfc7ab7fbe1484eb48fce51eea47f42493e6103a4e81adff39878a1113de555R17))
* Removed validation for `skill_id` in the `SkillSet` model's constructor, simplifying the setup process. (`src/database/models/skills_schema/SkillSet/SkillSet.ts`, [src/database/models/skills_schema/SkillSet/SkillSet.tsL17-L20](diffhunk://#diff-01a6f90964104090936c8bbe03bfe0f1e829e13876f9c0a74e40587f87c056c4L17-L20))

### New and updated API routes:

* Added a new route for creating skill sets (`POST /skill/create-set`), which validates input, creates a skill set, and returns the result. (`src/routes/skill/create-set.ts`, [src/routes/skill/create-set.tsR1-R33](diffhunk://#diff-7f7d448f0ca17417e522791c1768c19491ef020316b37137252502fb022dae77R1-R33))
* Added a new route for retrieving a skill by ID (`GET /skill/:skill_id`), which fetches a skill along with its associated language sets. (`src/routes/skill/skill_id.ts`, [src/routes/skill/skill_id.tsR1-R32](diffhunk://#diff-a19c2efd85799a379caa6e4822c29a40406b308802b0aaab8672cf17f1f0df00R1-R32))
* Added a new route for updating skill sets (`POST /skill/update-set`), which validates input and updates a skill set in the database. (`src/routes/skill/update-set.ts`, [src/routes/skill/update-set.tsR1-R33](diffhunk://#diff-41178043ed8c1ab1f5d506543026e48aebf9b8d6085b97b623a2095ad40d4978R1-R33))
* Added a new route for updating skills (`POST /skill/update`), which validates input and updates a skill in the database. (`src/routes/skill/update.ts`, [src/routes/skill/update.tsR1-R33](diffhunk://#diff-0d6a8b941f908eeb73676234c4d046913461098fea47eff66178cc45f6db7312R1-R33))

### Miscellaneous:

* Refactored imports in `src/containers/api-server.service.ts` for better organization and added new routes to the `ServerAPI` configuration. [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL5-R24) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR72-R76)

[FRCV-69]: https://feliperamosdev.atlassian.net/browse/FRCV-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ