### PR TITLE
[FRCV-71] Check all routes protections

### DIFF
--- a/src/database/models/companies_schema/Company/Company.ts
+++ b/src/database/models/companies_schema/Company/Company.ts
@@ -108,6 +108,10 @@ export default class Company extends CompanySet {
             throw new ErrorDatabase('Failed to fetch company', 'COMPANY_QUERY_ERROR');
          }
 
+         if (!companyData) {
+            return null;
+         }
+
          const companySetQuery = database.select('companies_schema', 'company_sets');
          companySetQuery.where({ company_id });
 

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -99,8 +99,12 @@ export default class Experience extends ExperienceSet {
          const { data = [], error } = await expBaseQuery.exec();
          const [ experienceData ] = data;
 
-         if (error || !experienceData) {
-            throw new ErrorDatabase('Experience not found', 'EXPERIENCE_NOT_FOUND');
+         if (error) {
+            throw new ErrorDatabase(error.message, error.code);
+         }
+
+         if (!experienceData) {
+            return null;
          }
 
          const experienceSetQuery = database.select('experiences_schema', 'experience_sets');

--- a/src/routes/company/company_id.ts
+++ b/src/routes/company/company_id.ts
@@ -9,7 +9,7 @@ export default new Route({
       const { company_id } = req.params;
       const companyId = parseInt(company_id, 10);
 
-      if (isNaN(companyId)) {
+      if (isNaN(companyId) || companyId < 0) {
          new ErrorResponseServerAPI('Invalid company ID', 400, 'INVALID_COMPANY_ID').send(res);
          return;
       }

--- a/src/routes/experience/experience_id.ts
+++ b/src/routes/experience/experience_id.ts
@@ -9,7 +9,7 @@ export default new Route({
       const { experience_id } = req.params;
       const experienceId = parseInt(experience_id, 10);
 
-      if (isNaN(experienceId)) {
+      if (isNaN(experienceId) || experienceId < 0) {
          new ErrorResponseServerAPI('Invalid experience ID', 400, 'INVALID_EXPERIENCE_ID').send(res);
          return;
       }

--- a/src/routes/experience/update-set.ts
+++ b/src/routes/experience/update-set.ts
@@ -5,6 +5,8 @@ import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorRespons
 export default new Route({
    method: 'POST',
    routePath: '/experience/update-set',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
       const { id, updates } = req.body;
 

--- a/src/routes/skill/skill_id.ts
+++ b/src/routes/skill/skill_id.ts
@@ -10,7 +10,7 @@ export default new Route({
       const { skill_id } = req.params;
       const skillId = Number(skill_id);
 
-      if (isNaN(skillId)) {
+      if (isNaN(skillId) || skillId < 0) {
          new ErrorResponseServerAPI('Invalid Skill ID', 400, 'INVALID_SKILL_ID').send(res);
          return;
       }

--- a/src/routes/skill/skill_id.ts
+++ b/src/routes/skill/skill_id.ts
@@ -10,8 +10,8 @@ export default new Route({
       const { skill_id } = req.params;
       const skillId = Number(skill_id);
 
-      if (isNaN(skillId) || skillId < 0) {
-         new ErrorResponseServerAPI('Skill ID is required', 400, 'SKILL_ID_REQUIRED').send(res);
+      if (isNaN(skillId)) {
+         new ErrorResponseServerAPI('Invalid Skill ID', 400, 'INVALID_SKILL_ID').send(res);
          return;
       }
 


### PR DESCRIPTION
[FRCV-71] Description
This pull request introduces several improvements to error handling and route configuration across the codebase. The key changes include refining error handling logic for database queries, adding authentication and role-based access control to a route, and updating validation for skill IDs.

### Error handling improvements:

* [`src/database/models/companies_schema/Company/Company.ts`](diffhunk://#diff-177be4ebcf7169758235a339b873c76b21bef65b73cabc316b9fbfafa6a1b114R111-R114): Added a check to return `null` if `companyData` is not found, instead of proceeding with further logic.
* [`src/database/models/experiences_schema/Experience/Experience.ts`](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L102-R107): Updated error handling to separate cases where an error occurs versus when no `experienceData` is found. Now returns `null` if `experienceData` is missing.

### Route configuration updates:

* [`src/routes/experience/update-set.ts`](diffhunk://#diff-8fbc443bebc4fe37fdabe12eb1d220bcd4ea29eb3fb0906ff9d8981823abf909R8-R9): Added `useAuth` and `allowedRoles` properties to enforce authentication and restrict access to users with `admin` or `master` roles.

### Validation improvements:

* [`src/routes/skill/skill_id.ts`](diffhunk://#diff-a19c2efd85799a379caa6e4822c29a40406b308802b0aaab8672cf17f1f0df00L13-R14): Refined the validation logic for `skill_id` to explicitly handle invalid values, replacing the "Skill ID is required" error with a more descriptive "Invalid Skill ID" error.

[FRCV-71]: https://feliperamosdev.atlassian.net/browse/FRCV-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ