### PR TITLE
[FRCV-74] Route /experience/:experience_id skills population issue

### DIFF
--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -112,7 +112,7 @@ export default class Experience extends ExperienceSet {
       }
    }
 
-   static async getFullSet(experienceId: number): Promise<Experience | null> {
+   static async getFullSet(experienceId: number, language_set?: string): Promise<Experience | null> {
       try {
          const expBaseQuery = database.select('experiences_schema', 'experiences');
          expBaseQuery.where({ 'experiences.id': experienceId });
@@ -137,7 +137,7 @@ export default class Experience extends ExperienceSet {
 
          experienceData.company = company;
          experienceData.languageSets = experienceSetData;
-         experienceData.skills = await Skill.getManyByIds(experienceData.skills);
+         experienceData.skills = await Skill.getManyByIds(experienceData.skills, language_set);
 
          return new Experience(experienceData);
       } catch (error: any) {

--- a/src/routes/experience/experience_id.ts
+++ b/src/routes/experience/experience_id.ts
@@ -16,7 +16,7 @@ export default new Route({
       }
 
       try {
-         const experience = await Experience.getFullSet(experienceId, language_set as string);
+         const experience = await Experience.getFullSet(experienceId, String(language_set));
          if (!experience) {
             new ErrorResponseServerAPI('Experience not found', 404, 'EXPERIENCE_NOT_FOUND').send(res);
             return;

--- a/src/routes/experience/experience_id.ts
+++ b/src/routes/experience/experience_id.ts
@@ -7,6 +7,7 @@ export default new Route({
    routePath: '/experience/:experience_id',
    controller: async (req, res) => {
       const { experience_id } = req.params;
+      const { language_set = 'en' } = req.query;
       const experienceId = parseInt(experience_id, 10);
 
       if (isNaN(experienceId) || experienceId < 0) {
@@ -15,7 +16,7 @@ export default new Route({
       }
 
       try {
-         const experience = await Experience.getFullSet(experienceId);
+         const experience = await Experience.getFullSet(experienceId, language_set as string);
          if (!experience) {
             new ErrorResponseServerAPI('Experience not found', 404, 'EXPERIENCE_NOT_FOUND').send(res);
             return;


### PR DESCRIPTION
## [FRCV-74] Description
This pull request introduces support for fetching localized data by adding a `language_set` parameter to the `getFullSet` method in the `Experience` class and updating the corresponding route to handle this new parameter. The main changes involve extending the database query functionality and ensuring the route controller passes the language preference correctly.

### Updates to `Experience` class:

* [`src/database/models/experiences_schema/Experience/Experience.ts`](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L115-R115): Added an optional `language_set` parameter to the `getFullSet` method to allow fetching localized data. Updated the method to pass this parameter to the `Skill.getManyByIds` function. [[1]](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L115-R115) [[2]](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L140-R140)

### Updates to route handling:

* [`src/routes/experience/experience_id.ts`](diffhunk://#diff-1e399dde7721ada517189a119223d262cd4e17ec9fd65406cf89c6bd12ad924bR10): Modified the route to extract a `language_set` query parameter (defaulting to 'en') and pass it to the `getFullSet` method when fetching experiences. [[1]](diffhunk://#diff-1e399dde7721ada517189a119223d262cd4e17ec9fd65406cf89c6bd12ad924bR10) [[2]](diffhunk://#diff-1e399dde7721ada517189a119223d262cd4e17ec9fd65406cf89c6bd12ad924bL18-R19)

[FRCV-74]: https://feliperamosdev.atlassian.net/browse/FRCV-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ