### PR TITLE
[FRCV-81] Fixing conflicts with docker service names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     environment:
       - NODE_ENV=production
     depends_on:
-      redis:
+      redis-service:
         condition: service_healthy
-      postgres:
+      postgres-service:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -24,9 +24,9 @@ services:
     environment:
       - NODE_ENV=production
     depends_on:
-      redis:
+      redis-service:
         condition: service_healthy
-      postgres:
+      postgres-service:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -43,9 +43,9 @@ services:
     environment:
       - NODE_ENV=production
     depends_on:
-      redis:
+      redis-service:
         condition: service_healthy
-      postgres:
+      postgres-service:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -62,9 +62,9 @@ services:
     environment:
       - NODE_ENV=production
     depends_on:
-      redis:
+      redis-service:
         condition: service_healthy
-      postgres:
+      postgres-service:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -73,9 +73,9 @@ services:
       - .env.local
     command: ['npm', 'run', 'start:socket-server']
 
-  redis:
+  redis-service:
     image: redis:7-alpine
-    container_name: redis
+    container_name: redis-service
     ports:
       - "6000:6000"
     restart: unless-stopped
@@ -91,21 +91,21 @@ services:
       retries: 3
       start_period: 10s
 
-  postgres:
+  postgres-service:
     image: postgres:15
-    container_name: postgres
+    container_name: postgres-service
     environment:
       - NODE_ENV=production
     env_file:
       - .env.local
     ports:
-      - "${DB_PORT}:${DB_PORT}"
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - feliperamos-net
     restart: unless-stopped
-    command: postgres -p ${DB_PORT}
+    command: postgres -p 5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h localhost -p $${DB_PORT} -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 30s


### PR DESCRIPTION
## [FRCV-81] Description
This pull request updates the `docker-compose.yml` file to standardize service naming conventions and simplify port configurations. The changes include renaming services and their associated container names, as well as replacing dynamic port variables with fixed values for improved clarity and consistency.

### Service naming standardization:
* Renamed `redis` to `redis-service` and updated all references, including `depends_on` conditions and the `container_name` field. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R10) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L27-R29) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L46-R48) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L65-R67) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L76-R78)
* Renamed `postgres` to `postgres-service` and updated all references, including `depends_on` conditions and the `container_name` field. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R10) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L27-R29) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L46-R48) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L65-R67) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L94-R108)

### Port configuration simplification:
* Replaced the dynamic `${DB_PORT}` variable with a fixed port value (`5432`) for the `postgres-service`, ensuring consistency and reducing complexity in the configuration.