### PR TITLE
[FRCV-77] Admin user new table fields

### DIFF
--- a/src/database/models/users_schema/AdminUser/AdminUser.ts
+++ b/src/database/models/users_schema/AdminUser/AdminUser.ts
@@ -1,16 +1,33 @@
 import bcrypt from 'bcrypt';
 import TableRow from '../../../../services/Database/models/TableRow';
 import database from '../../..';
-import { AdminUserPublic, CreateUserProps } from './AdminUser.types';
+import { AdminUserPublic, CreateUserProps, UserRoles } from './AdminUser.types';
 
-const PUBLIC_FIELDS = [ 'id', 'email', 'first_name', 'last_name', 'role' ];
+const PUBLIC_FIELDS = [
+   'id',
+   'email',
+   'first_name',
+   'last_name',
+   'role',
+   'avatar_url',
+   'portfolio_url',
+   'github_url',
+   'linkedin_url',
+   'whatsapp_url'
+];
 
 export default class AdminUser extends TableRow {
    public email: string;
+   public phone?: string;
    public password: string;
    public first_name: string;
    public last_name: string;
-   public role: 'master' | 'admin' | 'user';
+   public role: UserRoles;
+   public avatar_url?: string;
+   public portfolio_url?: string;
+   public github_url?: string;
+   public linkedin_url?: string;
+   public whatsapp_url?: string;
 
    constructor(data: any) {
       super('users_schema', 'admin_users', data);
@@ -21,17 +38,29 @@ export default class AdminUser extends TableRow {
 
       const {
          email,
+         phone,
          password,
          first_name,
          last_name,
-         role
+         role,
+         avatar_url,
+         portfolio_url,
+         github_url,
+         linkedin_url,
+         whatsapp_url
       } = data;
 
       this.email = email;
+      this.phone = phone;
       this.password = password;
       this.first_name = first_name;
       this.last_name = last_name;
       this.role = role;
+      this.avatar_url = avatar_url;
+      this.portfolio_url = portfolio_url;
+      this.github_url = github_url;
+      this.linkedin_url = linkedin_url;
+      this.whatsapp_url = whatsapp_url;
    }
 
    get name() {
@@ -42,15 +71,22 @@ export default class AdminUser extends TableRow {
       return {
          id: this.id,
          email: this.email,
+         phone: this.phone,
          name: this.name,
          first_name: this.first_name,
          last_name: this.last_name,
-         role: this.role
+         role: this.role,
+         avatar_url: this.avatar_url,
+         portfolio_url: this.portfolio_url,
+         github_url: this.github_url,
+         linkedin_url: this.linkedin_url,
+         whatsapp_url: this.whatsapp_url
       };
    }
 
    static async createMaster(masterData: {
       email: string;
+      phone?: string;
       password: string;
       first_name: string;
       last_name: string;
@@ -58,6 +94,7 @@ export default class AdminUser extends TableRow {
       try {
          const created = await this.create({
             email: masterData.email,
+            phone: masterData.phone,
             password: masterData.password,
             first_name: masterData.first_name,
             last_name: masterData.last_name,

--- a/src/database/models/users_schema/AdminUser/AdminUser.types.ts
+++ b/src/database/models/users_schema/AdminUser/AdminUser.types.ts
@@ -1,16 +1,25 @@
+export type UserRoles = 'master' | 'admin' | 'user';
+
 export interface CreateUserProps {
    email: string;
    password: string;
    first_name: string;
    last_name: string;
-   role?: 'master' | 'admin' | 'user';
+   role?: UserRoles;
+   phone?: string;
 }
 
 export interface AdminUserPublic {
    id?: number;
    email: string;
+   phone?: string;
    name: string;
    first_name: string;
    last_name: string;
-   role: 'master' | 'admin' | 'user';
+   role: UserRoles;
+   avatar_url?: string;
+   portfolio_url?: string;
+   github_url?: string;
+   linkedin_url?: string;
+   whatsapp_url?: string;
 };

--- a/src/database/tables/users_schema/admin_users.ts
+++ b/src/database/tables/users_schema/admin_users.ts
@@ -6,9 +6,15 @@ export default new Table({
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'email', type: 'VARCHAR(255)', unique: true },
+      { name: 'phone', type: 'VARCHAR(25)' },
       { name: 'password', type: 'VARCHAR(255)' },
       { name: 'first_name', type: 'VARCHAR(100)' },
       { name: 'last_name', type: 'VARCHAR(100)' },
-      { name: 'role', type: 'VARCHAR(50)', defaultValue: 'admin' }
+      { name: 'role', type: 'VARCHAR(50)', defaultValue: 'admin' },
+      { name: 'avatar_url', type: 'VARCHAR(255)' },
+      { name: 'portfolio_url', type: 'VARCHAR(255)' },
+      { name: 'github_url', type: 'VARCHAR(255)' },
+      { name: 'linkedin_url', type: 'VARCHAR(255)' },
+      { name: 'whatsapp_url', type: 'VARCHAR(255)' },
    ]
 });


### PR DESCRIPTION
## [FRCV-77] Description
This pull request introduces enhancements to the `AdminUser` model, adding support for additional user fields and refactoring the code for improved maintainability. The main changes include extending the user schema, updating the `AdminUser` class, and introducing a reusable type for user roles.

### Schema and model updates:

* Added new fields (`phone`, `avatar_url`, `portfolio_url`, `github_url`, `linkedin_url`, `whatsapp_url`) to the `AdminUser` schema to store additional user information (`src/database/tables/users_schema/admin_users.ts`).
* Updated the `AdminUser` class to include the new fields in its properties, constructor, and public field definitions (`src/database/models/users_schema/AdminUser/AdminUser.ts`). [[1]](diffhunk://#diff-b76bb3744221446c59a5ff45322cd678415e4aa7f9ee4758770870df3365fc74L4-R30) [[2]](diffhunk://#diff-b76bb3744221446c59a5ff45322cd678415e4aa7f9ee4758770870df3365fc74R41-R63) [[3]](diffhunk://#diff-b76bb3744221446c59a5ff45322cd678415e4aa7f9ee4758770870df3365fc74R74-R97)

### Type improvements:

* Introduced a reusable `UserRoles` type to replace hardcoded role strings (`'master'`, `'admin'`, `'user'`) and updated all related type definitions (`src/database/models/users_schema/AdminUser/AdminUser.types.ts`).

[FRCV-77]: https://feliperamosdev.atlassian.net/browse/FRCV-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ