### PR TITLE
[FRCV-76] Curriculums Schema, Table and Model

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -4,6 +4,7 @@ import companies_schema from './schemas/companies_schema';
 import experiences_schema from './schemas/experiences_schema';
 import skills_schema from './schemas/skills_schema';
 import users_schema from './schemas/users_schema';
+import curriculums_schema from './schemas/curriculums_schema';
 
 const database = new PostgresDB({
    dbName: process.env.POSTGRES_DB,
@@ -15,7 +16,8 @@ const database = new PostgresDB({
       users_schema,
       skills_schema,
       companies_schema,
-      experiences_schema
+      experiences_schema,
+      curriculums_schema
    ]
 });
 

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -1,0 +1,36 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { Experience } from '../../experiences_schema';
+import { Skill } from '../../skills_schema';
+import CVSet from '../CVSet/CVSet';
+import { CVSetSetup } from '../CVSet/CVSet.types';
+import { CVSetup } from './CV.types';
+
+export default class CV extends CVSet {
+   user_id?: number | null;
+   title: string;
+   is_master: boolean;
+   notes?: string;
+   experiences?: Experience[];
+   skills?: Skill[];
+
+   constructor(setup: Partial<CVSetup>) {
+      super(setup as CVSetSetup, 'curriculums_schema', 'cvs');
+
+      const {
+         title = '',
+         is_master = false,
+         notes = '',
+         user_id = null,
+         skills = [],
+         experiences = []
+      } = setup || {};
+
+      this.title = title;
+      this.is_master = Boolean(is_master);
+      this.notes = notes;
+      this.user_id = user_id;
+
+      this.experiences = experiences.map(exp => new Experience(exp));
+      this.skills = skills.map(skill => new Skill(skill));
+   }
+}

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -13,8 +13,8 @@ export default class CV extends CVSet {
    experiences?: Experience[];
    skills?: Skill[];
 
-   constructor(setup: Partial<CVSetup>) {
-      super(setup as CVSetSetup, 'curriculums_schema', 'cvs');
+   constructor(setup: CVSetup & CVSetSetup) {
+      super(setup, 'curriculums_schema', 'cvs');
 
       const {
          title = '',

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -1,0 +1,14 @@
+import { ExperienceSetup } from "../../experiences_schema/Experience/Experience.types";
+import { SkillSetup } from "../../skills_schema/Skill/Skill.types";
+
+export interface CVSetup {
+   id: number;
+   created_at: Date;
+   updated_at: Date;
+   title: string;
+   is_master: boolean;
+   user_id: number;
+   notes?: string;
+   experiences?: ExperienceSetup[];
+   skills?: SkillSetup[];
+}

--- a/src/database/models/curriculums_schema/CVSet/CVSet.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.ts
@@ -1,0 +1,25 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { CVSetSetup } from './CVSet.types';
+
+export default class CVSet extends TableRow {
+   user_id?: number | null;
+   professional_title: string;
+   brief_bio: string;
+   cv_id: number;
+
+   constructor(setup: CVSetSetup, schemaName: string = 'curriculums_schema', tableName: string = 'cv_sets') {
+      super(schemaName, tableName, setup);
+
+      const {
+         professional_title = '',
+         brief_bio = '',
+         user_id,
+         cv_id
+      } = setup || {};
+
+      this.professional_title = professional_title;
+      this.brief_bio = brief_bio;
+      this.user_id = user_id;
+      this.cv_id = cv_id;
+   }
+}

--- a/src/database/models/curriculums_schema/CVSet/CVSet.types.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.types.ts
@@ -1,0 +1,9 @@
+export interface CVSetSetup {
+   id: number;
+   created_at: Date;
+   updated_at: Date;
+   professional_title: string;
+   brief_bio: string;
+   user_id: number;
+   cv_id: number;
+}

--- a/src/database/schemas/curriculums_schema.ts
+++ b/src/database/schemas/curriculums_schema.ts
@@ -1,0 +1,8 @@
+import Schema from '../../services/Database/models/Schema';
+import cvs from '../tables/curriculums_schema/cvs';
+import cvSets from '../tables/curriculums_schema/cv_sets';
+
+export default new Schema({
+   name: 'curriculums_schema',
+   tables: [ cvs, cvSets ]
+});

--- a/src/database/tables/curriculums_schema/cv_sets.ts
+++ b/src/database/tables/curriculums_schema/cv_sets.ts
@@ -1,0 +1,22 @@
+import Table from "../../../services/Database/models/Table";
+
+export default new Table({
+   name: 'cv_sets',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'professional_title', type: 'VARCHAR(255)', notNull: true },
+      { name: 'brief_bio', type: 'VARCHAR(255)', notNull: true },
+      { name: 'user_id', type: 'INTEGER', notNull: true, relatedField: {
+         schema: 'users_schema',
+         table: 'admin_users',
+         field: 'id'
+      }},
+      { name: 'cv_id', type: 'INTEGER', notNull: true, relatedField: {
+         schema: 'curriculums_schema',
+         table: 'cvs',
+         field: 'id'
+      }},
+   ]
+});

--- a/src/database/tables/curriculums_schema/cv_sets.ts
+++ b/src/database/tables/curriculums_schema/cv_sets.ts
@@ -17,6 +17,6 @@ export default new Table({
          schema: 'curriculums_schema',
          table: 'cvs',
          field: 'id'
-      }},
+      }}
    ]
 });

--- a/src/database/tables/curriculums_schema/cvs.ts
+++ b/src/database/tables/curriculums_schema/cvs.ts
@@ -1,0 +1,20 @@
+import Table from "../../../services/Database/models/Table";
+
+export default new Table({
+   name: 'cvs',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'title', type: 'VARCHAR(255)', notNull: true },
+      { name: 'is_master', type: 'BOOLEAN', defaultValue: false },
+      { name: 'notes', type: 'TEXT' },
+      { name: 'cv_experiences', type: 'INTEGER[]' },
+      { name: 'cv_skills', type: 'INTEGER[]' },
+      { name: 'user_id', type: 'INTEGER', notNull: true, relatedField: {
+         schema: 'users_schema',
+         table: 'admin_users',
+         field: 'id'
+      }}
+   ]
+});

--- a/src/services/Database/models/TableRow.ts
+++ b/src/services/Database/models/TableRow.ts
@@ -8,6 +8,7 @@ export default class TableRow {
 
    public id?: number;
    public created_at: Date;
+   public updated_at?: Date;
 
    constructor(schemaName: string, tableName: string, rawData: any) {
       this._rawData = () => rawData;
@@ -18,13 +19,15 @@ export default class TableRow {
 
       const {
          id,
-         created_at
+         created_at,
+         updated_at
       } = rawData || {};
 
       const parsedId = id ? (isNaN(parseInt(id, 10)) ? undefined : parseInt(id, 10)) : undefined;
 
       this.id = parsedId;
       this.created_at = created_at;
+      this.updated_at = updated_at;
       this.schemaName = schemaName;
       this.tableName = tableName;
    }


### PR DESCRIPTION
## [FRCV-76] Description
This pull request introduces a new `curriculums_schema` to the database, along with its associated models and tables, to support curriculum-related data such as CVs and CV sets. Key changes include the addition of schema and table definitions, new model classes, and updates to the database initialization to integrate the new schema.

### Database Schema and Table Additions:
* [`src/database/schemas/curriculums_schema.ts`](diffhunk://#diff-9b465421bdf64ec5370eb1e4bb875bcdf52d7bd4380f3de3d14bdfa713d3b360R1-R8): Added a new schema, `curriculums_schema`, which includes `cvs` and `cv_sets` tables.
* [`src/database/tables/curriculums_schema/cvs.ts`](diffhunk://#diff-4bf6ea42e79ed11ca3988891b27ef7db53eaa424a1660e56d1ea524e5fdcb6e3R1-R20): Defined the `cvs` table with fields for CV details, such as `title`, `is_master`, `notes`, and references to user IDs and related experiences/skills.
* [`src/database/tables/curriculums_schema/cv_sets.ts`](diffhunk://#diff-9640d12e81b4f523445a131a8534d94120935fc4b39876f933e9c992b1f70594R1-R22): Defined the `cv_sets` table for grouping CVs, including fields like `professional_title`, `brief_bio`, and references to users and CVs.

### Model Class Additions:
* [`src/database/models/curriculums_schema/CV/CV.ts`](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR1-R36): Introduced the `CV` class to represent individual CVs, inheriting from `CVSet` and mapping fields such as `title`, `is_master`, `notes`, and associated experiences/skills.
* [`src/database/models/curriculums_schema/CVSet/CVSet.ts`](diffhunk://#diff-2237f6a296536586bb1c0355908319ae6d56e0726e135ef696f8a26f9a6a66ccR1-R25): Added the `CVSet` class to represent CV groupings, extending `TableRow` and including fields like `professional_title` and `brief_bio`.

### Type Definitions:
* [`src/database/models/curriculums_schema/CV/CV.types.ts`](diffhunk://#diff-f0f2b74971f6bb1e5e21a3e12e764353b93cccb509a9b0ccbebe31747ee3f1f3R1-R14): Defined the `CVSetup` interface for initializing `CV` instances, with fields for metadata, user associations, and related experiences/skills.
* [`src/database/models/curriculums_schema/CVSet/CVSet.types.ts`](diffhunk://#diff-130cff4ccd5b755f69eec48e08f8bb8464bf683b34597ba29b8461f8f712bbfeR1-R9): Defined the `CVSetSetup` interface for initializing `CVSet` instances, including metadata and references to users and CVs.

### Database Initialization Updates:
* [`src/database/index.ts`](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R7): Updated the database initialization to include the new `curriculums_schema`. [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R7) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352L18-R20)

### Core Framework Enhancements:
* [`src/services/Database/models/TableRow.ts`](diffhunk://#diff-211488fc6551f35ea39d34fd9717a5ac8e9c16310f7e51f21bde4bb5185efe1bR11): Added support for `updated_at` timestamps in the `TableRow` class to handle schema changes requiring this field. [[1]](diffhunk://#diff-211488fc6551f35ea39d34fd9717a5ac8e9c16310f7e51f21bde4bb5185efe1bR11) [[2]](diffhunk://#diff-211488fc6551f35ea39d34fd9717a5ac8e9c16310f7e51f21bde4bb5185efe1bL21-R30)

[FRCV-76]: https://feliperamosdev.atlassian.net/browse/FRCV-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ