### PR TITLE
[FRCV-79] Route /curriculum/create

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -31,6 +31,8 @@ import companyUpdate from '../routes/company/update';
 import companyUpdateSet from '../routes/company/update-set';
 import companyGet from '../routes/company/company_id';
 
+import curriculumCreate from '../routes/curriculum/create';
+
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : undefined;
 const {
@@ -83,7 +85,8 @@ export default new ServerAPI({
       companyUpdate,
       companyUpdateSet,
       companyQuery,
-      companyGet
+      companyGet,
+      curriculumCreate
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -1,17 +1,17 @@
-import TableRow from '../../../../services/Database/models/TableRow';
+import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import { Experience } from '../../experiences_schema';
 import { Skill } from '../../skills_schema';
 import CVSet from '../CVSet/CVSet';
 import { CVSetSetup } from '../CVSet/CVSet.types';
 import { CVSetup } from './CV.types';
+import database from '../../../../database';
 
 export default class CV extends CVSet {
-   user_id?: number | null;
-   title: string;
-   is_master: boolean;
-   notes?: string;
-   experiences?: Experience[];
-   skills?: Skill[];
+   public title: string;
+   public is_master: boolean;
+   public notes?: string;
+   public cv_experiences?: Experience[];
+   public cv_skills?: Skill[];
 
    constructor(setup: CVSetup & CVSetSetup) {
       super(setup, 'curriculums_schema', 'cvs');
@@ -20,17 +20,68 @@ export default class CV extends CVSet {
          title = '',
          is_master = false,
          notes = '',
-         user_id = null,
-         skills = [],
-         experiences = []
+         cv_skills = [],
+         cv_experiences = []
       } = setup || {};
 
       this.title = title;
       this.is_master = Boolean(is_master);
       this.notes = notes;
-      this.user_id = user_id;
 
-      this.experiences = experiences.map(exp => new Experience(exp));
-      this.skills = skills.map(skill => new Skill(skill));
+      this.cv_experiences = cv_experiences.map(exp => {
+         if (typeof exp === 'number') {
+            return exp;
+         } else {
+            return new Experience(exp);
+         }
+      });
+
+      this.cv_skills = cv_skills.map(skill => {
+         if (typeof skill === 'number') {
+            return skill;
+         } else {
+            return new Skill(skill);
+         }
+      });
+   }
+
+   get toSave() {
+      return {
+         title: this.title,
+         notes: this.notes,
+         is_master: this.is_master,
+         user_id: this.user_id,
+         cv_experiences: this.cv_experiences,
+         cv_skills: this.cv_skills,
+      }
+   }
+
+   async save(props?: CVSetup): Promise<CVSet> {
+      let processing;
+
+      try {
+         const { data = [], error } = await database.insert('curriculums_schema', 'cvs').data(this.toSave).returning().exec();
+         const [ savedCV ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to save CV', 'CV_SAVE_ERROR');
+         }
+
+         if (!savedCV) {
+            throw new ErrorDatabase('No CV saved', 'CV_SAVE_NO_DATA');
+         }
+
+         processing = savedCV;
+         const cvData = { ...this, ...props, cv_id: savedCV.id };
+         const newCVSet = await CVSet.createSet(cvData as CVSetSetup);
+
+         if (!newCVSet) {
+            throw new ErrorDatabase('Failed to create CV Set', 'CV_SET_CREATE_ERROR');
+         }
+
+         return new CV({ ...newCVSet, ...savedCV });
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'CV_SAVE_ERROR');
+      }
    }
 }

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -1,14 +1,11 @@
 import { ExperienceSetup } from "../../experiences_schema/Experience/Experience.types";
 import { SkillSetup } from "../../skills_schema/Skill/Skill.types";
+import { CVSetSetup } from "../CVSet/CVSet.types";
 
-export interface CVSetup {
-   id: number;
-   created_at: Date;
-   updated_at: Date;
+export interface CVSetup extends CVSetSetup {
    title: string;
-   is_master: boolean;
-   user_id: number;
+   is_master?: boolean;
    notes?: string;
-   experiences?: ExperienceSetup[];
-   skills?: SkillSetup[];
+   cv_experiences?: ExperienceSetup[];
+   cv_skills?: SkillSetup[];
 }

--- a/src/database/models/curriculums_schema/CVSet/CVSet.types.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.types.ts
@@ -1,9 +1,7 @@
 export interface CVSetSetup {
-   id: number;
-   created_at: Date;
-   updated_at: Date;
    professional_title: string;
    brief_bio: string;
-   user_id: number;
-   cv_id: number;
+   user_id?: number;
+   cv_id?: number;
+   language_set?: string;
 }

--- a/src/database/tables/curriculums_schema/cv_sets.ts
+++ b/src/database/tables/curriculums_schema/cv_sets.ts
@@ -8,6 +8,7 @@ export default new Table({
       { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'professional_title', type: 'VARCHAR(255)', notNull: true },
       { name: 'brief_bio', type: 'VARCHAR(255)', notNull: true },
+      { name: 'language_set', type: 'VARCHAR(2)', notNull: true },
       { name: 'user_id', type: 'INTEGER', notNull: true, relatedField: {
          schema: 'users_schema',
          table: 'admin_users',

--- a/src/routes/curriculum/create.ts
+++ b/src/routes/curriculum/create.ts
@@ -1,0 +1,49 @@
+import CV from '../../database/models/curriculums_schema/CV/CV';
+import { CVSetup } from '../../database/models/curriculums_schema/CV/CV.types';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Request, Response } from 'express';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/curriculum/create',
+   controller: async (req: Request, res: Response) => {
+      const { title, notes, cv_experiences = [], cv_skills = [], brief_bio, is_master, professional_title }: CVSetup = req.body;
+      const userId = req.session?.user?.id;
+
+      // if (!userId) {
+      //    new ErrorResponseServerAPI('User not authenticated.', 401, 'USER_NOT_AUTHENTICATED').send(res);
+      //    return;
+      // }
+
+      if (!title) {
+         new ErrorResponseServerAPI('Title is required.', 400, 'CURRICULUM_CREATE_VALIDATION_ERROR').send(res);
+         return;
+      }
+
+      try {
+         const newCurriculum = new CV({
+            title,
+            notes,
+            cv_experiences,
+            cv_skills,
+            brief_bio,
+            is_master,
+            professional_title,
+            user_id: userId || 1
+         });
+
+         const created = await newCurriculum.save();
+
+         if (!created) {
+            new ErrorResponseServerAPI('Failed to create curriculum', 500, 'CURRICULUM_CREATE_ERROR').send(res);
+            return;
+         }
+
+         res.status(201).send(created);
+      } catch (error) {
+         console.error('Error creating curriculum:', error);
+         new ErrorResponseServerAPI('Failed to create curriculum', 500, 'CURRICULUM_CREATE_ERROR').send(res);
+      }
+   }, 
+});

--- a/src/services/Database/models/TableRow.ts
+++ b/src/services/Database/models/TableRow.ts
@@ -7,7 +7,7 @@ export default class TableRow {
    public tableName: string;
 
    public id?: number;
-   public created_at: Date;
+   public created_at?: Date;
    public updated_at?: Date;
 
    constructor(schemaName: string, tableName: string, rawData: any) {


### PR DESCRIPTION
## [FRCV-79] Description
This pull request introduces a new curriculum creation feature and refactors the database models to support enhanced functionality. The key changes include adding a new API route for curriculum creation, updating the `CV` and `CVSet` models to include new fields and methods, and modifying the database schema to accommodate these updates.

### New Curriculum Creation Feature

* **New API Route**: Added a `POST /curriculum/create` route to handle curriculum creation requests. This includes validation for required fields like `title` and integrates with the `CV` model to save data to the database. (`src/routes/curriculum/create.ts`, [src/routes/curriculum/create.tsR1-R49](diffhunk://#diff-ce1d617490c8f8c5e592111ff08fe4317807120d02eb4dcd97459fdc102eb703R1-R49))
* **API Server Configuration**: Registered the new curriculum creation route in the API server configuration. (`src/containers/api-server.service.ts`, [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR34-R35) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL86-R89)

### Database Model Enhancements

* **`CV` Model Updates**: Refactored the `CV` model to include new fields (`cv_experiences`, `cv_skills`) and a `save` method for inserting data into the database. Removed unused fields like `user_id`. (`src/database/models/curriculums_schema/CV/CV.ts`, [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL1-R14) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL23-R85)
* **`CVSet` Model Updates**: Added a `language_set` field and a static `createSet` method for creating CV sets in the database. (`src/database/models/curriculums_schema/CVSet/CVSet.ts`, [[1]](diffhunk://#diff-2237f6a296536586bb1c0355908319ae6d56e0726e135ef696f8a26f9a6a66ccR1-R11) [[2]](diffhunk://#diff-2237f6a296536586bb1c0355908319ae6d56e0726e135ef696f8a26f9a6a66ccL17-R55)

### Schema and Type Adjustments

* **Database Schema Changes**: Updated the `cv_sets` table to include a new `language_set` column. (`src/database/tables/curriculums_schema/cv_sets.ts`, [src/database/tables/curriculums_schema/cv_sets.tsR11](diffhunk://#diff-9640d12e81b4f523445a131a8534d94120935fc4b39876f933e9c992b1f70594R11))
* **Type Definitions**: Adjusted the `CVSetup` and `CVSetSetup` interfaces to reflect the updated fields and optional properties. (`src/database/models/curriculums_schema/CV/CV.types.ts`, [[1]](diffhunk://#diff-f0f2b74971f6bb1e5e21a3e12e764353b93cccb509a9b0ccbebe31747ee3f1f3R3-R10); `src/database/models/curriculums_schema/CVSet/CVSet.types.ts`, [[2]](diffhunk://#diff-130cff4ccd5b755f69eec48e08f8bb8464bf683b34597ba29b8461f8f712bbfeL2-R6)

### General Improvements

* **Base Class Update**: Made `created_at` and `updated_at` fields optional in the `TableRow` base class to support more flexible model instantiation. (`src/services/Database/models/TableRow.ts`, [src/services/Database/models/TableRow.tsL10-R10](diffhunk://#diff-211488fc6551f35ea39d34fd9717a5ac8e9c16310f7e51f21bde4bb5185efe1bL10-R10))

[FRCV-79]: https://feliperamosdev.atlassian.net/browse/FRCV-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ