### PR TITLE
[FRCV-82] Route /curriculum/user-cvs

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -32,6 +32,7 @@ import companyUpdateSet from '../routes/company/update-set';
 import companyGet from '../routes/company/company_id';
 
 import curriculumCreate from '../routes/curriculum/create';
+import curriculumUserCVs from '../routes/curriculum/user-cvs';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : undefined;
@@ -86,7 +87,8 @@ export default new ServerAPI({
       companyUpdateSet,
       companyQuery,
       companyGet,
-      curriculumCreate
+      curriculumCreate,
+      curriculumUserCVs
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -8,4 +8,5 @@ export interface CVSetup extends CVSetSetup {
    notes?: string;
    cv_experiences?: ExperienceSetup[];
    cv_skills?: SkillSetup[];
+   cv_owner?: number; 
 }

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -137,7 +137,7 @@ export default class Experience extends ExperienceSet {
 
          experienceData.company = company;
          experienceData.languageSets = experienceSetData;
-         experienceData.skills = await Skill.getManyByIds(experienceData.skills, language_set);
+         experienceData.skills = await Skill.getManyById(experienceData.skills, language_set);
 
          return new Experience(experienceData);
       } catch (error: any) {
@@ -168,7 +168,7 @@ export default class Experience extends ExperienceSet {
 
             // Populate skills data
             if (Array.isArray(exp.skills) && exp.skills.length) {
-               exp.skills = await Skill.getManyByIds(exp.skills, language_set);
+               exp.skills = await Skill.getManyById(exp.skills, language_set);
             }
          }
 
@@ -183,6 +183,21 @@ export default class Experience extends ExperienceSet {
       }
    }
 
+   static async getManyById(ids: number[], language_set: string = 'en'): Promise<Experience[]> {
+      try {
+         const query = database.select('experiences_schema', 'experience_sets');
+         query.where(ids.map(id => ({ experience_id: id, language_set })));
+
+         const { data = [], error } = await query.exec();
+         if (error) {
+            throw new ErrorDatabase('Failed to fetch Experiences by ID: ' + error.message, 'EXPERIENCE_QUERY_ERROR');
+         }
+
+         return data.map(exp => new Experience(exp));
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code);
+      }
+   }
    static async update(id: number, updates: Partial<Experience>): Promise<Experience> {
       try {
          const updateQuery = database.update('experiences_schema', 'experiences');

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -110,7 +110,7 @@ export default class Skill extends SkillSet {
       }
    }
 
-   static async getManyByIds(skillIds: number[], language_set?: string): Promise<Skill[]> {
+   static async getManyById(skillIds: number[], language_set?: string): Promise<Skill[]> {
       if (!Array.isArray(skillIds)) {
          return [];
       }

--- a/src/database/tables/curriculums_schema/cvs.ts
+++ b/src/database/tables/curriculums_schema/cvs.ts
@@ -10,11 +10,6 @@ export default new Table({
       { name: 'is_master', type: 'BOOLEAN', defaultValue: false },
       { name: 'notes', type: 'TEXT' },
       { name: 'cv_experiences', type: 'INTEGER[]' },
-      { name: 'cv_skills', type: 'INTEGER[]' },
-      { name: 'user_id', type: 'INTEGER', notNull: true, relatedField: {
-         schema: 'users_schema',
-         table: 'admin_users',
-         field: 'id'
-      }}
+      { name: 'cv_skills', type: 'INTEGER[]' }
    ]
 });

--- a/src/routes/curriculum/create.ts
+++ b/src/routes/curriculum/create.ts
@@ -7,14 +7,16 @@ import { Request, Response } from 'express';
 export default new Route({
    method: 'POST',
    routePath: '/curriculum/create',
+   useAuth: true,
+   allowedRoles: [ 'admin', 'master' ],
    controller: async (req: Request, res: Response) => {
       const { title, notes, cv_experiences = [], cv_skills = [], brief_bio, is_master, professional_title }: CVSetup = req.body;
       const userId = req.session?.user?.id;
 
-      // if (!userId) {
-      //    new ErrorResponseServerAPI('User not authenticated.', 401, 'USER_NOT_AUTHENTICATED').send(res);
-      //    return;
-      // }
+      if (!userId) {
+         new ErrorResponseServerAPI('User not authenticated.', 401, 'USER_NOT_AUTHENTICATED').send(res);
+         return;
+      }
 
       if (!title) {
          new ErrorResponseServerAPI('Title is required.', 400, 'CURRICULUM_CREATE_VALIDATION_ERROR').send(res);
@@ -30,7 +32,7 @@ export default new Route({
             brief_bio,
             is_master,
             professional_title,
-            user_id: userId || 1
+            user_id: userId
          });
 
          const created = await newCurriculum.save();

--- a/src/routes/curriculum/user-cvs.ts
+++ b/src/routes/curriculum/user-cvs.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import CV from '../../database/models/curriculums_schema/CV/CV';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/curriculum/user-cvs',
+   useAuth: true,
+   allowedRoles: [ 'admin', 'master' ],
+   controller: async (req: Request, res: Response) => {
+      const userId = req.session?.user?.id;
+      const { language_set } = req.query;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User ID is required', 400, 'USER_ID_REQUIRED').send(res);
+         return;
+      }
+
+      try {
+         const cvs = await CV.getUserCVs(userId, language_set as string);
+
+         if (!cvs) {
+            new ErrorResponseServerAPI('No CVs found for this user', 404, 'CVS_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(cvs);
+      } catch (error) {
+         console.error('Error processing curriculum query:', error);
+         new ErrorResponseServerAPI('Internal Server Error', 500, 'INTERNAL_SERVER_ERROR').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-82] Description
Introduces a new GET /curriculum/user-cvs route to fetch CVs for authenticated users. Adds CV.getUserCVs static method, updates experience and skill model methods for consistent ID-based retrieval, and enforces authentication and role checks on curriculum creation. Minor schema and type adjustments included.

[FRCV-82]: https://feliperamosdev.atlassian.net/browse/FRCV-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ