### PR TITLE
[FRCV-83] Route /curriculum/:cv_id

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -32,6 +32,7 @@ import companyUpdateSet from '../routes/company/update-set';
 import companyGet from '../routes/company/company_id';
 
 import curriculumCreate from '../routes/curriculum/create';
+import curriculumGet from '../routes/curriculum/cv_id';
 import curriculumUserCVs from '../routes/curriculum/user-cvs';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
@@ -88,6 +89,7 @@ export default new ServerAPI({
       companyQuery,
       companyGet,
       curriculumCreate,
+      curriculumGet,
       curriculumUserCVs
    ],
    onListen: function () {

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -10,8 +10,9 @@ export default class CV extends CVSet {
    public title: string;
    public is_master: boolean;
    public notes?: string;
-   public cv_experiences?: Experience[];
-   public cv_skills?: Skill[];
+   public cv_experiences?: (Experience | number)[];
+   public cv_skills?: (Skill | number)[];
+   public languageSets: CVSet[];
 
    constructor(setup: CVSetup & CVSetSetup) {
       super(setup, 'curriculums_schema', 'cvs');
@@ -21,12 +22,14 @@ export default class CV extends CVSet {
          is_master = false,
          notes = '',
          cv_skills = [],
-         cv_experiences = []
+         cv_experiences = [],
+         languageSets = []
       } = setup || {};
 
       this.title = title;
       this.is_master = Boolean(is_master);
       this.notes = notes;
+      this.languageSets = languageSets;
 
       this.cv_experiences = cv_experiences.map(exp => {
          if (typeof exp === 'number') {
@@ -57,6 +60,64 @@ export default class CV extends CVSet {
          user_id: this.user_id,
          cv_experiences: this.cv_experiences,
          cv_skills: this.cv_skills,
+      }
+   }
+
+   async populateSets(): Promise<CVSet[]> {
+      try {
+         const cvQuery = database.select('curriculums_schema', 'cv_sets');
+         cvQuery.where({ cv_id: this.id });
+
+         const { data = [], error } = await cvQuery.exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to fetch CV by ID', 'CV_FETCH_ERROR');
+         }
+
+         const parsed = data.map(cvData => new CVSet(cvData));
+
+         this.languageSets = parsed;
+         return parsed;
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'CV_FETCH_ERROR');
+      }
+   }
+
+   async populateExperiences(): Promise<Experience[]> {
+      if (!this.cv_experiences || this.cv_experiences.length === 0) {
+         this.cv_experiences = [];
+         return this.cv_experiences as [];
+      }
+
+      try {
+         const [ expIndex ] = this.cv_experiences;
+
+         if (typeof expIndex === 'number') {
+            this.cv_experiences = await Experience.getManyById(this.cv_experiences as number[], this.language_set || 'en');
+         }
+
+         return this.cv_experiences as Experience[];
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'CV_EXPERIENCES_FETCH_ERROR');
+      }
+   }
+
+   async populateSkills(): Promise<Skill[]> {
+      if (!this.cv_skills || this.cv_skills.length === 0) {
+         this.cv_skills = [];
+         return this.cv_skills as [];
+      }
+
+      try {
+         const [ skillIndex ] = this.cv_skills;
+
+         if (typeof skillIndex === 'number') {
+            this.cv_skills = await Skill.getManyById(this.cv_skills as number[], this.language_set || 'en');
+         }
+
+         return this.cv_skills as Skill[];
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'CV_SKILLS_FETCH_ERROR');
       }
    }
 
@@ -108,6 +169,34 @@ export default class CV extends CVSet {
          }
 
          return data.map(cvData => new CV(cvData));
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'CV_FETCH_ERROR');
+      }
+   }
+
+   static async getFullById(id: number): Promise<CV | null> {
+      try {
+         const cvQuery = database.select('curriculums_schema', 'cvs');
+         cvQuery.where({ id });
+
+         const { data = [], error } = await cvQuery.exec();
+         const [ cvData ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to fetch CV by ID', 'CV_FETCH_ERROR');
+         }
+
+         if (!cvData) {
+            return null;
+         }
+
+         const cv = new CV(cvData);
+
+         await cv.populateSets();
+         await cv.populateExperiences();
+         await cv.populateSkills();
+
+         return cv;
       } catch (error: any) {
          throw new ErrorDatabase(error.message, error.code || 'CV_FETCH_ERROR');
       }

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -1,12 +1,14 @@
 import { ExperienceSetup } from "../../experiences_schema/Experience/Experience.types";
 import { SkillSetup } from "../../skills_schema/Skill/Skill.types";
+import CVSet from "../CVSet/CVSet";
 import { CVSetSetup } from "../CVSet/CVSet.types";
 
 export interface CVSetup extends CVSetSetup {
    title: string;
    is_master?: boolean;
    notes?: string;
-   cv_experiences?: ExperienceSetup[];
-   cv_skills?: SkillSetup[];
+   cv_experiences?: (ExperienceSetup | number)[];
+   cv_skills?: (SkillSetup | number)[];
    cv_owner?: number; 
+   languageSets?: CVSet[];
 }

--- a/src/routes/curriculum/cv_id.ts
+++ b/src/routes/curriculum/cv_id.ts
@@ -1,0 +1,38 @@
+import CV from '../../database/models/curriculums_schema/CV/CV';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/curriculum/:cv_id',
+   useAuth: true,
+   allowedRoles: [ 'admin', 'master' ],
+   controller: async (req, res) => {
+      const { cv_id } = req.params || {};
+
+      if (!cv_id) {
+         new ErrorResponseServerAPI('CV ID is required', 400, 'CV_ID_REQUIRED').send(res);
+         return;
+      }
+
+      if (isNaN(Number(cv_id))) {
+         new ErrorResponseServerAPI('Invalid CV ID format', 400, 'CV_ID_INVALID').send(res);
+         return;
+      }
+
+      try {
+         const cvId = Number(cv_id);
+         const cv = await CV.getFullById(cvId);
+
+         if (!cv) {
+            new ErrorResponseServerAPI('CV not found', 404, 'CV_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(cv);
+      } catch (error) {
+         console.error('Error fetching CV:', error);
+         new ErrorResponseServerAPI('Failed to fetch CV', 500, 'CV_FETCH_ERROR').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-83] Description
Introduces a GET /curriculum/:cv_id route for fetching a CV with all related sets, experiences, and skills. Updates the CV model to support population of related entities and adds a static getFullById method. Adjusts types to support new data structures.

[FRCV-83]: https://feliperamosdev.atlassian.net/browse/FRCV-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ