### PR TITLE
[FRCV-85] Route /curriculum/update-set

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -34,6 +34,7 @@ import companyGet from '../routes/company/company_id';
 import curriculumCreate from '../routes/curriculum/create';
 import curriculumGet from '../routes/curriculum/cv_id';
 import curriculumUpdate from '../routes/curriculum/update';
+import curriculumUpdateSet from '../routes/curriculum/update-set';
 import curriculumUserCVs from '../routes/curriculum/user-cvs';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
@@ -92,6 +93,7 @@ export default new ServerAPI({
       curriculumCreate,
       curriculumGet,
       curriculumUpdate,
+      curriculumUpdateSet,
       curriculumUserCVs
    ],
    onListen: function () {

--- a/src/database/models/curriculums_schema/CVSet/CVSet.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.ts
@@ -54,4 +54,30 @@ export default class CVSet extends TableRow {
          throw new ErrorDatabase(error.message, error.code);
       }
    }
+
+   static async updateSet(id: number, updates: Partial<CVSetSetup>): Promise<CVSet | null> {
+      try {
+         const query = database.update('curriculums_schema', 'cv_sets');
+
+         query.set(updates);
+         query.where({ id });
+         query.returning();
+
+         const { data = [], error } = await query.exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to update CV Set', 'CV_SET_UPDATE_ERROR');
+         }
+
+         const [ updatedSet ] = data;
+
+         if (!updatedSet) {
+            throw new ErrorDatabase('No CV Set found with the provided ID after update', 'CV_SET_NOT_FOUND');
+         }
+
+         return new CVSet(updatedSet);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code);
+      }
+   }
 }

--- a/src/routes/curriculum/update-set.ts
+++ b/src/routes/curriculum/update-set.ts
@@ -1,0 +1,32 @@
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Route } from '../../services';
+import CVSet from '../../database/models/curriculums_schema/CVSet/CVSet';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/curriculum/update-set',
+   useAuth: true,
+   allowedRoles: [ 'admin', 'master' ],
+   controller: async (req, res) => {
+      const { id, updates } = req.body;
+
+      if (!id || !updates || typeof updates !== 'object') {
+         new ErrorResponseServerAPI('Missing required fields', 400, 'INVALID_REQUEST').send(res);
+         return;
+      }
+
+      try {
+         const updated = await CVSet.updateSet(id, updates);
+
+         if (!updated) {
+            new ErrorResponseServerAPI('Curriculum set not found or update failed', 404, 'CURRICULUM_SET_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(updated);
+      } catch (error) {
+         console.error('Error updating curriculum set:', error);
+         new ErrorResponseServerAPI('Failed to update curriculum set', 500, 'SERVER_ERROR').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-85] Description
Introduces a POST /curriculum/update-set route for updating CV sets, restricted to admin and master roles. Adds CVSet.updateSet method to handle database updates and integrates the new route into the API server.

[FRCV-85]: https://feliperamosdev.atlassian.net/browse/FRCV-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ