### PR TITLE
[FRCV-87] Route /curriculum/create-set

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -32,6 +32,7 @@ import companyUpdateSet from '../routes/company/update-set.route';
 import companyGet from '../routes/company/company_id.route';
 
 import curriculumCreate from '../routes/curriculum/create.route';
+import curriculumCreateSet from '../routes/curriculum/create-set.route';
 import curriculumGet from '../routes/curriculum/cv_id.route';
 import curriculumUpdate from '../routes/curriculum/update.route';
 import curriculumUpdateSet from '../routes/curriculum/update-set.route';
@@ -91,6 +92,7 @@ export default new ServerAPI({
       companyQuery,
       companyGet,
       curriculumCreate,
+      curriculumCreateSet,
       curriculumGet,
       curriculumUpdate,
       curriculumUpdateSet,

--- a/src/database/tables/curriculums_schema/cv_sets.ts
+++ b/src/database/tables/curriculums_schema/cv_sets.ts
@@ -6,8 +6,8 @@ export default new Table({
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
-      { name: 'professional_title', type: 'VARCHAR(255)', notNull: true },
-      { name: 'brief_bio', type: 'VARCHAR(255)', notNull: true },
+      { name: 'professional_title', type: 'VARCHAR(255)' },
+      { name: 'brief_bio', type: 'VARCHAR(255)' },
       { name: 'language_set', type: 'VARCHAR(2)', notNull: true },
       { name: 'user_id', type: 'INTEGER', notNull: true, relatedField: {
          schema: 'users_schema',

--- a/src/routes/curriculum/create-set.route.ts
+++ b/src/routes/curriculum/create-set.route.ts
@@ -1,0 +1,39 @@
+import CVSet from '../../database/models/curriculums_schema/CVSet/CVSet';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/curriculum/create-set',
+   useAuth: true,
+   allowedRoles: [ 'admin', 'master' ],
+   controller: async (req, res) => {
+      const { cv_id, professional_title, brief_bio, language_set = 'en' } = req.body;
+      const userId = req.session?.user?.id || 1;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User not authenticated.', 401, 'USER_NOT_AUTHENTICATED').send(res);
+         return;
+      }
+
+      if (!cv_id) {
+         new ErrorResponseServerAPI('CV ID is required.', 400, 'CV_ID_REQUIRED').send(res);
+         return;
+      }
+
+      try {
+         const newSet = await CVSet.createSet({
+            cv_id,
+            professional_title,
+            brief_bio,
+            user_id: userId,
+            language_set
+         });
+
+         res.status(201).send(newSet);
+      } catch (error) {
+         console.error('Error creating CV Set:', error);
+         new ErrorResponseServerAPI('Failed to create CV Set.', 500, 'CV_SET_CREATE_ERROR').send(res);
+      }
+   },
+});

--- a/src/routes/curriculum/create.route.ts
+++ b/src/routes/curriculum/create.route.ts
@@ -19,7 +19,7 @@ export default new Route({
       }
 
       if (!title) {
-         new ErrorResponseServerAPI('Title is required.', 400, 'CURRICULUM_CREATE_VALIDATION_ERROR').send(res);
+         new ErrorResponseServerAPI('Title is required.', 400, 'ROUTE_VALIDATION_ERROR').send(res);
          return;
       }
 


### PR DESCRIPTION
## [FRCV-87] Description
Introduces a new POST /curriculum/create-set route for creating CV sets, updates the cv_sets table to make professional_title and brief_bio fields optional, and registers the new route in the API server. Also refines error code for missing title in curriculum creation route.

[FRCV-87]: https://feliperamosdev.atlassian.net/browse/FRCV-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ