### PR TITLE
[FRCV-80] Population Issues

### DIFF
--- a/src/database/models/companies_schema/Company/Company.ts
+++ b/src/database/models/companies_schema/Company/Company.ts
@@ -59,8 +59,8 @@ export default class Company extends CompanySet {
       });
 
       return new Company({
-         ...createdCompany,
          ...isSet,
+         ...createdCompany,
       });
    }
 

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -102,7 +102,10 @@ export default class Experience extends ExperienceSet {
             experience_id: createdExperience.id,
          });
 
-         return new Experience({ ...createdExperience, ...createdDefaultSet });
+         return new Experience({
+            ...createdDefaultSet,
+            ...createdExperience
+         });
       } catch (error: any) {
          throw new ErrorDatabase('Failed to create Experience: ' + error.message, 'EXPERIENCE_CREATION_ERROR');
       }

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -43,7 +43,10 @@ export default class Skill extends SkillSet {
             user_id: skillData.user_id
          });
 
-         return new Skill({ ...createdSkill, ...skillSetCreated });
+         return new Skill({
+            ...skillSetCreated,
+            ...createdSkill
+         });
       } catch (error) {
          throw error;
       }
@@ -74,7 +77,7 @@ export default class Skill extends SkillSet {
       try {
          const query = database.select('skills_schema', 'skill_sets');
          query.where({ user_id: userId, language_set });
-         query.populate('skill_id', ['name', 'category', 'level']);
+         query.populate('skill_id', ['skills.id', 'name', 'category', 'level']);
 
          const { data = [], error } = await query.exec();
          if (error) {


### PR DESCRIPTION
## [FRCV-80] Description
This pull request updates the order of object spread properties in several model classes to ensure consistent behavior and modifies a database query to include a more specific field reference. The most important changes are grouped below by their themes.

### Object Spread Property Order Updates:
* [`src/database/models/companies_schema/Company/Company.ts`](diffhunk://#diff-177be4ebcf7169758235a339b873c76b21bef65b73cabc316b9fbfafa6a1b114L62-R63): Reordered the spread properties in the `Company` constructor to prioritize `isSet` over `createdCompany`.
* [`src/database/models/experiences_schema/Experience/Experience.ts`](diffhunk://#diff-c721c2cc70982dd229e1b931b2326a98aad28f39de52426fb3f81a05d8175390L105-R108): Reordered the spread properties in the `Experience` constructor to prioritize `createdDefaultSet` over `createdExperience`.
* [`src/database/models/skills_schema/Skill/Skill.ts`](diffhunk://#diff-b534653f310c495b6837443bf7cab817dcf9e516d8af6d688d9e1f45996f4d87L46-R49): Reordered the spread properties in the `Skill` constructor to prioritize `skillSetCreated` over `createdSkill`.

### Database Query Update:
* [`src/database/models/skills_schema/Skill/Skill.ts`](diffhunk://#diff-b534653f310c495b6837443bf7cab817dcf9e516d8af6d688d9e1f45996f4d87L77-R80): Updated the `populate` method in a database query to include the specific field `skills.id` for better clarity and accuracy.

[FRCV-80]: https://feliperamosdev.atlassian.net/browse/FRCV-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ