### PR TITLE
[FRCV-90] Adjusts to load FE Home from CV

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -44,6 +44,7 @@ import curriculumSetMaster from '../routes/curriculum/set-master.route';
 import curriculumDelete from '../routes/curriculum/delete.route';
 
 import userUpdate from '../routes/user/update.route';
+import userMasterCV from '../routes/user/master-cv.route';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : undefined;
@@ -109,7 +110,8 @@ export default new ServerAPI({
       curriculumGet,
       curriculumSetMaster,
       curriculumDelete,
-      userUpdate
+      userUpdate,
+      userMasterCV
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -73,6 +73,18 @@ export default class Experience extends ExperienceSet {
       }
    }
 
+   async populateSkills(language_set: string) {
+      if (!this.skills?.length) {
+         return;
+      }
+
+      try {
+         this.skills = await Skill.getManyById(this.rawData.skills, language_set);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'SKILL_QUERY_ERROR');
+      }
+   }
+
    static async create(data: ExperienceCreateSetup): Promise<Experience> {
       try {
          const savedQuery = await database.insert('experiences_schema', 'experiences').data({
@@ -221,9 +233,10 @@ export default class Experience extends ExperienceSet {
          const parsed = data.map(exp => new Experience(exp));
          for (const experience of parsed) {
             await experience.populateCompany(language_set);
+            await experience.populateSkills(language_set);
          }
 
-         return parsed;
+         return parsed.filter(exp => exp.language_set === language_set);
       } catch (error: any) {
          throw new ErrorDatabase(error.message, error.code);
       }

--- a/src/routes/user/master-cv.route.ts
+++ b/src/routes/user/master-cv.route.ts
@@ -1,0 +1,20 @@
+import { CV } from '../../database/models/curriculums_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/user/master-cv',
+   controller: async (req, res) => {
+      const { language_set } = req.query;
+      const lang = language_set ? String(language_set) : undefined;
+
+      try {
+         const masterCV = await CV.getMaster(lang);
+         res.status(200).send(masterCV);
+      } catch (error) {
+         console.error('Error fetching master CV:', error);
+         new ErrorResponseServerAPI('Internal Server Error', 500, 'ERROR_FETCHING_MASTER_CV');
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-90] Description
Introduces a new GET /user/master-cv route to retrieve the master CV. Updates the CV and Experience models to support fetching and populating master CV data, including related skills and experiences. Also registers the new route in the API server.

[FRCV-90]: https://feliperamosdev.atlassian.net/browse/FRCV-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ