### PR TITLE
[FRCV-93] PDF Generation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <meta charset="UTF-8">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <title>FelipeRamos API</title>
+</head>
+<body>
+   <h1>Felipe Ramos - API</h1>
+   <p>Public route for Felipe Ramos API files.</p>
+</body>
+</html>

--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -75,6 +75,7 @@ export default new ServerAPI({
    corsOrigin: CORS_ORIGIN,
    sslConfig: sslConfig,
    autoInitialize: true,
+   publicPath: 'public',
    httpEndpoints: [
       loginRoute,
       authUserRoute,

--- a/src/containers/virtual-browser.service.ts
+++ b/src/containers/virtual-browser.service.ts
@@ -3,8 +3,8 @@ import VirtualBrowser from '../services/VirtualBrowser';
 export default new VirtualBrowser({
    autoInit: true,
    async onInit(virtualBrowser) {
-      const initialPage = await virtualBrowser.newPage('initial-page', 'https://feliperamos.dev');
-      debugger
+      console.log('Virtual Browser initialized');
+      console.log(`Viewport: ${virtualBrowser.viewPort.width}x${virtualBrowser.viewPort.height}`);
    },
    onError(error) {
       console.error(error);

--- a/src/services/ServerAPI/ServerAPI.ts
+++ b/src/services/ServerAPI/ServerAPI.ts
@@ -34,7 +34,7 @@ class ServerAPI extends Microservice {
    public app_queue: Array<() => void> = [];
    public API_SECRET: string;
    public sessionCookiesMaxAge: number;
-   public staticPath?: string;
+   public publicPath?: string;
    public redisURL: string;
    public corsOrigin: string[];
    public jsonLimit: string;
@@ -68,7 +68,7 @@ class ServerAPI extends Microservice {
       const {
          projectName = 'default-server',
          API_SECRET,
-         staticPath,
+         publicPath,
          sslConfig,
          FE_ORIGIN,
 
@@ -99,7 +99,7 @@ class ServerAPI extends Microservice {
       this.app_queue = [];
       this.API_SECRET = API_SECRET;
       this.sessionCookiesMaxAge = sessionCookiesMaxAge;
-      this.staticPath = staticPath;
+      this.publicPath = publicPath;
       this.redisURL = redisURL;
       this.corsOrigin = corsOrigin;
       this.jsonLimit = jsonLimit;
@@ -245,8 +245,8 @@ class ServerAPI extends Microservice {
          throw new ErrorServerAPI('You need to provide a API SECRET to start the server!', 'API_SECRET_REQUIRED');
       }
 
-      if (this.staticPath) {
-         this.app.use(express.static(this.rootPath + this.staticPath));
+      if (this.publicPath) {
+         this.app.use(express.static(this.publicPath));
       }
 
       // Register routes after all middleware is set up

--- a/src/services/ServerAPI/ServerAPI.types.ts
+++ b/src/services/ServerAPI/ServerAPI.types.ts
@@ -25,7 +25,7 @@ export interface SSLConfig {
 export interface ServerAPISetup extends MicroserviceSetup {
    projectName?: string;
    API_SECRET: string;
-   staticPath?: string;
+   publicPath?: string;
    sslConfig?: SSLConfig;
    FE_ORIGIN?: string;
    PORT?: number;

--- a/src/services/VirtualBrowser/ErrorVirtualBrowser.ts
+++ b/src/services/VirtualBrowser/ErrorVirtualBrowser.ts
@@ -1,10 +1,12 @@
 class ErrorVirtualBrowser extends Error {
    public code: string;
+   public error: boolean;
 
    constructor(message: string = 'Virtual Browser Error', code: string = 'VIRTUAL_BROWSER_ERROR') {
       super(message);
 
       this.name = '[VirtualBrowser]';
+      this.error = true;
       this.code = code;
       this.message = message;
    }

--- a/src/services/VirtualBrowser/VirtualBrowser.helpers.ts
+++ b/src/services/VirtualBrowser/VirtualBrowser.helpers.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import ErrorVirtualBrowser from './ErrorVirtualBrowser';
+
+export async function writeFile(filePath: string, data: Uint8Array): Promise<boolean> {
+   try {
+      await fs.promises.writeFile(filePath, data);
+      return true;
+   } catch (error: any) {
+      throw new ErrorVirtualBrowser(`Failed to write file at ${filePath}: ${error.message}`, error.code || 'FILE_WRITE_ERROR');
+   }
+}

--- a/src/services/VirtualBrowser/VirtualBrowser.types.ts
+++ b/src/services/VirtualBrowser/VirtualBrowser.types.ts
@@ -17,3 +17,8 @@ export interface VirtualBrowserPageSetup {
    id: string;
    startURL?: string;
 }
+
+export interface VirtualBrowserSuccessResponse<T> {
+   success: true;
+   data: T;
+}


### PR DESCRIPTION
## [FRCV-93] Description
This pull request introduces several updates across the codebase, including changes to the `ServerAPI` class, enhancements to the `VirtualBrowser` service, and the addition of a public-facing HTML file. The most significant changes involve replacing `staticPath` with `publicPath` in the `ServerAPI`, adding PDF generation functionality to the `VirtualBrowserPage`, and improving error handling and utility functions for the `VirtualBrowser`.

### ServerAPI updates:
* Replaced `staticPath` with `publicPath` across the `ServerAPI` class, its constructor, and its type definition, ensuring middleware uses the new `publicPath` for serving static files. (`[[1]](diffhunk://#diff-a0692e55edd7790cbd4d0c80a70b30efa89c6facac77da622d3250efd100bff3L37-R37)`, `[[2]](diffhunk://#diff-a0692e55edd7790cbd4d0c80a70b30efa89c6facac77da622d3250efd100bff3L71-R71)`, `[[3]](diffhunk://#diff-a0692e55edd7790cbd4d0c80a70b30efa89c6facac77da622d3250efd100bff3L102-R102)`, `[[4]](diffhunk://#diff-a0692e55edd7790cbd4d0c80a70b30efa89c6facac77da622d3250efd100bff3L248-R249)`, `[[5]](diffhunk://#diff-3fa081f3042689bc63f5e8de3ad33885ef543f24a95ead1c1ec3ec17eb45f463L28-R28)`)
* Added `publicPath` configuration to the `ServerAPI` initialization in `api-server.service.ts`. (`[src/containers/api-server.service.tsR78](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR78)`)

### VirtualBrowser enhancements:
* Introduced a `toPDF` method in `VirtualBrowserPage` to generate PDFs, write them to a file, and return the PDF buffer. This includes error handling for missing file paths or page initialization. (`[src/services/VirtualBrowser/VirtualBrowserPage.tsR75-R105](diffhunk://#diff-b80e624382ece71f9efe6764f8e13e01b0d4863c977f8c3861ef420cc0aa7352R75-R105)`)
* Added a `writeFile` helper function to handle file writing with error handling in `VirtualBrowser.helpers.ts`. (`[src/services/VirtualBrowser/VirtualBrowser.helpers.tsR1-R11](diffhunk://#diff-8418dce88b5059f611e71a932b321fa9ed2a81e9517d6dec8bce8c19242ae1f0R1-R11)`)
* Updated `VirtualBrowserPage` to make `startURL` optional and added a `waitUntil` option for page navigation. (`[[1]](diffhunk://#diff-b80e624382ece71f9efe6764f8e13e01b0d4863c977f8c3861ef420cc0aa7352L1-R9)`, `[[2]](diffhunk://#diff-b80e624382ece71f9efe6764f8e13e01b0d4863c977f8c3861ef420cc0aa7352L24-L27)`, `[[3]](diffhunk://#diff-b80e624382ece71f9efe6764f8e13e01b0d4863c977f8c3861ef420cc0aa7352L52-R49)`)

### Error handling improvements:
* Enhanced the `ErrorVirtualBrowser` class by adding an `error` property for better error tracking. (`[src/services/VirtualBrowser/ErrorVirtualBrowser.tsR3-R9](diffhunk://#diff-04f8339a169b5279f9e60c5e0d8f6bb638f1bbe77ca6e4dfba7a77196bdea889R3-R9)`)

### Additional changes:
* Added a new `VirtualBrowserSuccessResponse` interface for standardizing success responses. (`[src/services/VirtualBrowser/VirtualBrowser.types.tsR20-R24](diffhunk://#diff-8bc16c673cd959dd25f698c27efe6fd441db5c17eb58e4b83b3f4accc5dc90dfR20-R24)`)
* Created a public-facing `index.html` file to serve as the default landing page for the API. (`[public/index.htmlR1-R12](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR1-R12)`)