### PR TITLE
[FRCV-97] Database Events on its contexts

### DIFF
--- a/src/services/Database/builders/DeleteSQL.ts
+++ b/src/services/Database/builders/DeleteSQL.ts
@@ -13,6 +13,8 @@ import PostgresDB from '../PostgresDB';
  * @param {string} tableName - The table name.
  */
 class DeleteSQL extends SQL {
+   public queryType: string;
+
    /**
     * @constructor
     * @param {PostgresDB} database - The database instance with a pool.query method.
@@ -22,6 +24,7 @@ class DeleteSQL extends SQL {
    constructor(database: PostgresDB, schemaName: string, tableName: string) {
       super(database, schemaName, tableName);
 
+      this.queryType = 'DELETE';
       this.isAllowedNullWhere = false;
    }
 

--- a/src/services/Database/builders/InsertSQL.ts
+++ b/src/services/Database/builders/InsertSQL.ts
@@ -13,6 +13,7 @@ import ErrorDatabase from '../ErrorDatabase';
  */
 class InsertSQL extends SQL {
    private insertClause: string;
+   public queryType: string;
 
    /**
     * @constructor
@@ -23,6 +24,7 @@ class InsertSQL extends SQL {
    constructor(database: any, schemaName: string, tableName: string) {
       super(database, schemaName, tableName);
       
+      this.queryType = 'INSERT';
       this.insertClause = '';
    }
 

--- a/src/services/Database/builders/SQL.ts
+++ b/src/services/Database/builders/SQL.ts
@@ -2,6 +2,8 @@ import { JoinConfig, WhereCondition, QueryResult } from '../types/builders/SQL.t
 import ErrorDatabase from '../ErrorDatabase';
 import DataBase from '../Database';
 import { RelatedFieldSetup } from '../types/models/RelatedField.types';
+import Table from '../models/Table';
+import { Result } from 'pg';
 
 interface WhereConditionValue {
   operator?: string;
@@ -29,6 +31,8 @@ class SQL {
    protected onClause: string;
    protected values: any[];
    protected isAllowedNullWhere: boolean;
+   protected queryType: string;
+   public response: Result | null;
 
    /**
     * @constructor
@@ -41,6 +45,7 @@ class SQL {
          throw new ErrorDatabase('A valid database instance with a query method is required.', 'DATABASE_INSTANCE_REQUIRED');
       }
 
+      this.queryType = '';
       this.database = database;
       this.schemaName = schemaName;
       this.tableName = tableName;
@@ -53,6 +58,7 @@ class SQL {
       this.onClause = '';
       this.values = [];
       this.isAllowedNullWhere = false;
+      this.response = null;
    }
 
    /**
@@ -355,8 +361,10 @@ class SQL {
     */
    async exec(): Promise<QueryResult> {
       try {
+         this.triggerBeforeEvent();
          const response = await this.database.pool.query(this.toString(), this.values);
 
+         this.triggerAfterEvent(response);
          if (!response || !response.rows) {
             throw new ErrorDatabase('No data returned from the database.', 'DATABASE_NO_DATA', response);
          }
@@ -380,7 +388,7 @@ class SQL {
             mappedError = { ...error, code: 404 }; 
          }
 
-         throw new ErrorDatabase(`Database query execution failed: ${error.message}`, 'DATABASE_QUERY_ERROR', error);
+         throw new ErrorDatabase(`Database query execution failed: ${mappedError.message}`, 'DATABASE_QUERY_ERROR', mappedError);
       }
    }
 
@@ -400,6 +408,63 @@ class SQL {
     */
    toString(): string {
       throw new ErrorDatabase('toString method must be implemented in subclasses.', 'TO_STRING_NOT_IMPLEMENTED');
+   }
+
+   getTable(): Table {
+      const schema = this.database.getSchema(this.schemaName);
+      return schema?.getTable(this.tableName);
+   }
+
+   triggerBeforeEvent(): void {
+      const table = this.getTable();
+
+      if (!table) {
+         return;
+      }
+
+      switch (this.queryType) {
+         case 'SELECT':
+            table.triggerEvent('onBeforeSelect', this);
+            break;
+         case 'INSERT':
+            table.triggerEvent('onBeforeInsert', this);
+            break;
+         case 'UPDATE':
+            table.triggerEvent('onBeforeUpdate', this);
+            break;
+         case 'DELETE':
+            table.triggerEvent('onBeforeDelete', this);
+            break;
+         default:
+            throw new ErrorDatabase(`Unsupported query type: ${this.queryType}`, 'UNSUPPORTED_QUERY_TYPE');
+      }
+   }
+
+   triggerAfterEvent(response: Result): void {
+      const table = this.getTable();
+
+      if (!table) {
+         return;
+      }
+
+      this.response = response;
+
+      switch (this.queryType) {
+         case 'SELECT':
+            table.   triggerEvent('onAfterSelect', this);
+            break;
+         case 'INSERT':
+            table.triggerEvent('onAfterInsert', this);
+            break;
+         case 'UPDATE':
+            table.triggerEvent('onAfterUpdate', this);
+            break;
+         case 'DELETE':
+            table.triggerEvent('onAfterDelete', this);
+            break;
+         default:
+            throw new ErrorDatabase(`Unsupported query type: ${this.queryType}`, 'UNSUPPORTED_QUERY_TYPE');
+      }
    }
 }
 

--- a/src/services/Database/builders/SelectSQL.ts
+++ b/src/services/Database/builders/SelectSQL.ts
@@ -15,6 +15,7 @@ import ErrorDatabase from '../ErrorDatabase';
 class SelectSQL extends SQL {
    private selectClause: string;
    private sortClause: string;
+   public queryType: string;
 
    /**
     * @constructor
@@ -25,6 +26,7 @@ class SelectSQL extends SQL {
    constructor(database: any, schemaName: string, tableName: string) {
       super(database, schemaName, tableName);
 
+      this.queryType = 'SELECT';
       this.selectClause = '';
       this.sortClause = '';
    }

--- a/src/services/Database/builders/UpdateSQL.ts
+++ b/src/services/Database/builders/UpdateSQL.ts
@@ -14,6 +14,7 @@ import ErrorDatabase from '../ErrorDatabase';
 class UpdateSQL extends SQL {
    private updateClause: string;
    private setClause: string;
+   public queryType: string;
 
    /**
     * @constructor
@@ -24,6 +25,7 @@ class UpdateSQL extends SQL {
    constructor (database: any, schemaName: string, tableName: string) {
       super(database, schemaName, tableName);
       
+      this.queryType = 'UPDATE';
       this.updateClause = `UPDATE ${this.tablePath}`;
       this.setClause = '';
    }


### PR DESCRIPTION
## [FRCV-97] Description
This pull request introduces enhancements to the `SQL` class and its subclasses (`DeleteSQL`, `InsertSQL`, `SelectSQL`, and `UpdateSQL`) to support query type tracking and event triggering before and after query execution. These changes improve extensibility by enabling table-specific event handling for different query types.

### Enhancements to query type tracking:
* Added a `queryType` property to the `SQL` class and its subclasses (`DeleteSQL`, `InsertSQL`, `SelectSQL`, `UpdateSQL`) to track the type of query being executed. The property is initialized in the constructors of the respective subclasses (`queryType` set to `'DELETE'`, `'INSERT'`, `'SELECT'`, and `'UPDATE'`). 

### Event triggering for query execution:
* Added `triggerBeforeEvent` and `triggerAfterEvent` methods in the `SQL` class to trigger table-specific events (e.g., `onBeforeInsert`, `onAfterUpdate`) based on the query type. These methods utilize the new `getTable` method to retrieve the associated table and invoke the appropriate event handlers.
* Integrated `triggerBeforeEvent` and `triggerAfterEvent` calls into the `exec` method of the `SQL` class to ensure events are triggered before and after query execution. 

### Additional improvements:
* Introduced a `response` property in the `SQL` class to store the query result, which is updated in `triggerAfterEvent`.
* Enhanced error handling in the `exec` method by mapping database errors to include a `404` code when appropriate and improving error messaging. 

[FRCV-97]: https://feliperamosdev.atlassian.net/browse/FRCV-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ