### PR TITLE
[FRCV-100] Update CV PDF Skills Events

### DIFF
--- a/src/database/tables/companies_schema/companies.ts
+++ b/src/database/tables/companies_schema/companies.ts
@@ -1,4 +1,7 @@
+import { sendToCreateCVPDF } from '../../../helpers/database.helper';
+import { Company } from '../../../database/models/companies_schema';
 import Table from '../../../services/Database/models/Table';
+import { locales } from '../../../app.config';
 
 export default new Table({
    name: 'companies',
@@ -9,5 +12,24 @@ export default new Table({
       { name: 'location', type: 'VARCHAR(255)', notNull: true },
       { name: 'site_url', type: 'VARCHAR(255)' },
       { name: 'logo_url', type: 'VARCHAR(255)' },
-   ]
+   ],
+   events: {
+      onAfterUpdate: async (query) => {
+         const updatedCompany = query.firstRow;
+         
+         try {
+            const company = new Company(updatedCompany);
+            const relatedCVs = await company.getRelatedCVs();
+
+            relatedCVs.forEach((cv) => {
+               locales.forEach((locale) => {
+                  console.log(`PDF Request for the CV: ${cv.id} in locale: ${locale}`);
+                  sendToCreateCVPDF({ cv_id: cv.id, language_set: locale });
+               });
+            });
+         } catch (error) {
+            console.error('Error in onAfterUpdate event:', error);
+         }
+      }
+   }
 });

--- a/src/database/tables/skills_schema/skills.ts
+++ b/src/database/tables/skills_schema/skills.ts
@@ -1,4 +1,8 @@
+import { locales } from '../../../app.config';
+import { Skill } from '../../../database/models/skills_schema';
 import Table from '../../../services/Database/models/Table';
+import { sendToCreateCVPDF } from '../../../helpers/database.helper';
+import { CV } from '@/database/models/curriculums_schema';
 
 export default new Table({
    name: 'skills',
@@ -8,5 +12,26 @@ export default new Table({
       { name: 'name', type: 'VARCHAR(255)', notNull: true },
       { name: 'category', type: 'VARCHAR(255)', notNull: true },
       { name: 'level', type: 'INTEGER', notNull: true }
-   ]
+   ],
+   events: {
+      onAfterUpdate: async (query) => {
+         const updatedSkill = query.firstRow;
+         if (!updatedSkill) {
+            return;
+         }
+
+         try {
+            const skill = new Skill(updatedSkill);
+            const relatedCVs = await skill.getRelatedCVs();
+
+            relatedCVs.forEach((cv: CV) => {
+               locales.forEach(language_set => {
+                  sendToCreateCVPDF({ cv_id: cv.id, language_set });
+               });
+            });
+         } catch (error) {
+            console.error('Error creating skill instance:', error);
+         }
+      }
+   }
 });

--- a/src/services/Database/builders/SQL.ts
+++ b/src/services/Database/builders/SQL.ts
@@ -370,7 +370,7 @@ class SQL {
     */
    async exec(): Promise<QueryResult> {
       try {
-         this.triggerBeforeEvent();
+         await this.triggerBeforeEvent();
          const response = await this.database.pool.query(this.toString(), this.values);
 
          this.triggerAfterEvent(response);
@@ -424,7 +424,7 @@ class SQL {
       return schema?.getTable(this.tableName);
    }
 
-   triggerBeforeEvent(): void {
+   triggerBeforeEvent(): void | Promise<void> {
       const table = this.getTable();
 
       if (!table) {


### PR DESCRIPTION
## [FRCV-100] Description
This pull request introduces functionality to fetch and process related data (experiences and CVs) for companies and skills, and adds event-driven behavior for database updates. It also includes a minor improvement to the SQL execution flow. Below is a breakdown of the most important changes:

### Enhancements to Company and Skill Models:
* Added `getRelatedExperiences` and `getRelatedCVs` methods to the `Company` class to fetch experiences and CVs associated with a company. These methods handle database queries and error handling. (`src/database/models/companies_schema/Company/Company.ts`, [src/database/models/companies_schema/Company/Company.tsR35-R70](diffhunk://#diff-177be4ebcf7169758235a339b873c76b21bef65b73cabc316b9fbfafa6a1b114R35-R70))
* Added `getRelatedExperiences` and `getRelatedCVs` methods to the `Skill` class to fetch experiences and CVs associated with a skill, including direct CVs tied to the skill. (`src/database/models/skills_schema/Skill/Skill.ts`, [src/database/models/skills_schema/Skill/Skill.tsR25-R79](diffhunk://#diff-b534653f310c495b6837443bf7cab817dcf9e516d8af6d688d9e1f45996f4d87R25-R79))

### Database Table Event Handling:
* Introduced an `onAfterUpdate` event for the `companies` table to trigger PDF generation for related CVs whenever a company record is updated. (`src/database/tables/companies_schema/companies.ts`, [src/database/tables/companies_schema/companies.tsL12-R34](diffhunk://#diff-868ea54a45f40d733f9be5305f78caccc1d86091a5f0a5f3bf35df64a7d5ca9fL12-R34))
* Added an `onAfterUpdate` event for the `skills` table to trigger PDF generation for related CVs whenever a skill record is updated. (`src/database/tables/skills_schema/skills.ts`, [src/database/tables/skills_schema/skills.tsL11-R36](diffhunk://#diff-5a82374d7a3d5e5769b6882603a043a8834129c32861a73b115821e253cb6701L11-R36))

### Improvements to SQL Execution:
* Made the `triggerBeforeEvent` method in the `SQL` class asynchronous, ensuring that any asynchronous operations in "before" events are awaited before executing the query. (`src/services/Database/builders/SQL.ts`, [[1]](diffhunk://#diff-521a48051e83b250520d85212c6d0432c19c5ebb4091b9b80703db6eb3cb2a0aL373-R373) [[2]](diffhunk://#diff-521a48051e83b250520d85212c6d0432c19c5ebb4091b9b80703db6eb3cb2a0aL427-R427)

[FRCV-100]: https://feliperamosdev.atlassian.net/browse/FRCV-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ