### PR TITLE
[FRCV-101] CV PDF update on user events

### DIFF
--- a/src/helpers/parse.helper.ts
+++ b/src/helpers/parse.helper.ts
@@ -21,5 +21,5 @@ export function cvPdfPath(cv: Partial<CV>): string {
    }
 
    const userName = cv.user.name.replace(/ /g, '_');
-   return `pdf/cv/${userName}-CV_${cv.language_set}_${cv.id}.pdf`;
+   return `pdf/cv/${userName}-CV_${cv.id}_${cv.language_set}.pdf`;
 }


### PR DESCRIPTION
## [FRCV-101] Description
This pull request introduces changes to enhance the functionality of the `admin_users` table by adding an event hook for generating CV PDFs after updates, and modifies the CV PDF path generation logic for consistency. Below are the key changes grouped by theme:

### Enhancements to `admin_users` table:

* Added an `onAfterUpdate` event to the `admin_users` table schema in `src/database/tables/users_schema/admin_users.ts`. This event retrieves the updated user's CVs and triggers the generation of CV PDFs in all supported locales using the `sendToCreateCVPDF` helper. Error handling is included to log any issues during the process.

### CV PDF generation logic:

* Updated the `cvPdfPath` function in `src/helpers/parse.helper.ts` to modify the order of parameters in the generated file path. The `cv.id` now appears before `cv.language_set` for better consistency and readability.

### Supporting imports:

* Added imports for `CV`, `locales`, and `sendToCreateCVPDF` in `src/database/tables/users_schema/admin_users.ts` to support the new `onAfterUpdate` event functionality.

[FRCV-101]: https://feliperamosdev.atlassian.net/browse/FRCV-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ