### PR TITLE
[FRCV-102] Download CV (FE Sync)

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -6,6 +6,7 @@ import { CVSetSetup } from '../CVSet/CVSet.types';
 import { CVSetup } from './CV.types';
 import database from '../../../../database';
 import { AdminUser } from '../../users_schema';
+import { AdminUserPublic } from '../../users_schema/AdminUser/AdminUser.types';
 
 export default class CV extends CVSet {
    public title: string;
@@ -125,6 +126,25 @@ export default class CV extends CVSet {
       }
    }
 
+   async populateUser(): Promise<AdminUserPublic | null> {
+      if (!this.cv_owner_id) {
+         return null;
+      }
+
+      try {
+         const user = await AdminUser.getById(this.cv_owner_id);
+
+         if (!user) {
+            throw null;
+         }
+         
+         this.user = user.toPublic();
+         return this.user;
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'CV_USER_FETCH_ERROR');
+      }
+   }
+
    async save(props?: CVSetup): Promise<CVSet> {
       let processing;
 
@@ -196,6 +216,7 @@ export default class CV extends CVSet {
          for (const cvData of parsedCV) {
             await cvData.populateSkills();
             await cvData.populateExperiences();
+            await cvData.populateUser();
          }
 
          return parsedCV;
@@ -274,6 +295,7 @@ export default class CV extends CVSet {
          await cv.populateSets();
          await cv.populateExperiences();
          await cv.populateSkills();
+         await cv.populateUser();
 
          return cv;
       } catch (error: any) {

--- a/src/database/models/curriculums_schema/CVSet/CVSet.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.ts
@@ -3,6 +3,7 @@ import TableRow from '../../../../services/Database/models/TableRow';
 import { CVSetSetup } from './CVSet.types';
 import database from '../../../../database';
 import { AdminUser } from '../../users_schema';
+import { AdminUserPublic } from '../../users_schema/AdminUser/AdminUser.types';
 
 export default class CVSet extends TableRow {
    public user_id?: number | null;
@@ -10,7 +11,7 @@ export default class CVSet extends TableRow {
    public summary?: string;
    public cv_id?: number;
    public language_set: string;
-   public user: AdminUser;
+   public user: AdminUser | AdminUserPublic;
 
    constructor(setup: CVSetSetup, schemaName: string = 'curriculums_schema', tableName: string = 'cv_sets') {
       super(schemaName, tableName, setup);

--- a/src/database/models/users_schema/AdminUser/AdminUser.ts
+++ b/src/database/models/users_schema/AdminUser/AdminUser.ts
@@ -212,6 +212,31 @@ export default class AdminUser extends TableRow {
       }
    }
 
+   static async getById(userId: number): Promise<AdminUser | null> {
+      if (!userId) {
+         throw new ErrorDatabase('User ID is required to fetch user.', 'USER_ID_REQUIRED');
+      }
+
+      try {
+         const query = database.select('users_schema', 'admin_users');
+
+         query.selectFields(PUBLIC_FIELDS);
+         query.where({ id: userId });
+         query.limit(1);
+
+         const { data = [] } = await query.exec();
+         const [ user ] = data;
+
+         if (!user) {
+            return null;
+         }
+
+         return new AdminUser(user);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'USER_FETCH_ERROR');
+      }
+   }
+
    static async validateUser(email: string, password: string): Promise<AdminUserPublic | null> {
       if (!email || !password) {
          throw new Error('Email and password are required for validation.');


### PR DESCRIPTION
## [FRCV-102] Description
This pull request introduces functionality to fetch and populate user data for `CV` and `CVSet` entities, along with adding a utility method to retrieve user information by ID in the `AdminUser` class. The changes enhance the ability to handle user-related data within the curriculum schema models. Below are the most important changes grouped by theme:

### User Population in `CV` and `CVSet`:

* Added a new method `populateUser` in the `CV` class to fetch and populate user data based on `cv_owner_id`. This method uses the `AdminUser.getById` utility and converts the user data to its public representation 
* Updated existing methods in the `CV` class (`parseCV` and `getCVById`) to call `populateUser`, ensuring user data is included when processing or retrieving CVs
* Modified the `CVSet` class to allow the `user` property to accept both `AdminUser` and `AdminUserPublic` types, reflecting the changes in how user data is handled

### Utility Method in `AdminUser`:

* Added a static method `getById` in the `AdminUser` class to fetch user details by ID. This method validates the input, queries the database, and returns an `AdminUser` instance or `null` if no user is found 

[FRCV-102]: https://feliperamosdev.atlassian.net/browse/FRCV-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ