### PR TITLE
[FRCV-108] CV PDF Improvements (FE Sync)

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -10,6 +10,7 @@ import { AdminUserPublic } from '../../users_schema/AdminUser/AdminUser.types';
 
 export default class CV extends CVSet {
    public title: string;
+   public experience_time: number | null;
    public is_master: boolean;
    public notes?: string;
    public cv_experiences?: (Experience | number)[];
@@ -17,11 +18,22 @@ export default class CV extends CVSet {
    public languageSets: CVSet[];
    public cv_owner_id?: number;
 
+   static populateFields = [
+      'cvs.id',
+      'title',
+      'is_master',
+      'experience_time',
+      'notes',
+      'cv_experiences',
+      'cv_skills'
+   ]
+
    constructor(setup: CVSetup & CVSetSetup) {
       super(setup, 'curriculums_schema', 'cvs');
 
       const {
          title = '',
+         experience_time = 0,
          is_master = false,
          notes = '',
          cv_owner_id,
@@ -32,6 +44,7 @@ export default class CV extends CVSet {
       } = setup || {};
 
       this.title = title;
+      this.experience_time = experience_time;
       this.is_master = Boolean(is_master);
       this.notes = notes;
       this.languageSets = languageSets;
@@ -205,7 +218,7 @@ export default class CV extends CVSet {
             getQuery.where({ user_id, language_set });
          }
 
-         getQuery.populate('cv_id', ['cvs.id', 'title', 'is_master', 'notes', 'cv_experiences', 'cv_skills']);
+         getQuery.populate('cv_id', this.populateFields);
          const { data = [], error } = await getQuery.exec();
 
          if (error) {
@@ -233,7 +246,7 @@ export default class CV extends CVSet {
       try {
          const cvQuery = database.select('curriculums_schema', 'cv_sets');
          cvQuery.where({ cv_id: id, language_set });
-         cvQuery.populate('cv_id', ['cvs.id', 'title', 'is_master', 'notes', 'cv_experiences', 'cv_skills']);
+         cvQuery.populate('cv_id', this.populateFields);
          cvQuery.populate('user_id', [
             'cvs.id',
             'first_name',

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -5,6 +5,7 @@ import { CVSetSetup } from "../CVSet/CVSet.types";
 
 export interface CVSetup extends CVSetSetup {
    title: string;
+   experience_time?: number;
    is_master?: boolean;
    notes?: string;
    cv_experiences?: (ExperienceSetup | number)[];

--- a/src/database/tables/curriculums_schema/cvs.ts
+++ b/src/database/tables/curriculums_schema/cvs.ts
@@ -9,6 +9,7 @@ export default new Table({
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'title', type: 'VARCHAR(255)', notNull: true },
+      { name: 'experience_time', type: 'DECIMAL(2,1)' },
       { name: 'is_master', type: 'BOOLEAN', defaultValue: false },
       { name: 'notes', type: 'TEXT' },
       { name: 'cv_experiences', type: 'INTEGER[]' },


### PR DESCRIPTION
## [FRCV-108] Description
This pull request introduces a new `experience_time` field to the `CV` model in the `curriculums_schema`. The changes include updates to the database schema, model class, and related query logic to support this new field.

### Database schema update:
* Added a new column `experience_time` of type `DECIMAL(2,1)` to the `cvs` table.

### Model updates:
* Added a new `experience_time` property to the `CV` class, with a default value of `0` in the constructor. [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR13-R36) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR47)
* Introduced a static `populateFields` array in the `CV` class, including `experience_time` along with other fields to simplify query population logic.

### Query logic updates:
* Replaced hardcoded field lists in `populate` calls with the new `populateFields` array for consistency and maintainability. [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL208-R221) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL236-R249)

### Type definition updates:
* Updated the `CVSetup` interface to include the optional `experience_time` property.

[FRCV-108]: https://feliperamosdev.atlassian.net/browse/FRCV-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ