### PR TITLE
[FRCV-106] Delete PDF when CV is deleted

### DIFF
--- a/src/containers/routes/virtual-browser/cv-create-pdf.route.ts
+++ b/src/containers/routes/virtual-browser/cv-create-pdf.route.ts
@@ -32,7 +32,8 @@ export default new EventEndpoint({
             return done(new EventEndpoint.Error('Failed to create PDF template page!', 'PAGE_CREATION_FAILED'));
          }
 
-         const pdfBuffer = await page.toPDF(cvPdfPath(cv), {
+         const pdfPath = cvPdfPath(cv.user.name, Number(cv.id), language_set);
+         const pdfBuffer = await page.toPDF(pdfPath, {
             printBackground: true
          });
 

--- a/src/containers/routes/virtual-browser/cv-delete-pdf.route.ts
+++ b/src/containers/routes/virtual-browser/cv-delete-pdf.route.ts
@@ -1,0 +1,25 @@
+import { cvPdfPath } from '../../../helpers/parse.helper';
+import { EventEndpoint } from '../../../services';
+import ErrorEventEndpoint from '../../../services/EventEndpoint/ErrorEventEndpoint';
+import { deleteFile } from '../../../services/VirtualBrowser/VirtualBrowser.helpers';
+
+export default new EventEndpoint({
+   path: '/virtual-browser/cv-delete-pdf',
+   controller: async (params = {}, done = () => {}) => {
+      const { cv_id, language_set = 'en', userFullName } = params;
+      
+      try {
+         const pdfPath = cvPdfPath(userFullName, cv_id, language_set);
+         const deleted = await deleteFile(pdfPath);
+
+         if (!deleted) {
+            return done(new ErrorEventEndpoint('Failed to delete CV PDF', 'CV_DELETE_PDF_ERROR'));
+         }
+
+         done({ success: true });
+      } catch (error) {
+         console.error('Error deleting CV PDF:', error);
+         return done(new ErrorEventEndpoint('Failed to delete CV PDF', 'CV_DELETE_PDF_ERROR'));
+      }
+   }
+});

--- a/src/containers/virtual-browser.service.ts
+++ b/src/containers/virtual-browser.service.ts
@@ -1,11 +1,13 @@
 import 'dotenv/config';
+
 import VirtualBrowser from '../services/VirtualBrowser';
 import cvCreatePdfRoute from './routes/virtual-browser/cv-create-pdf.route';
+import cvDeletePdfRoute from './routes/virtual-browser/cv-delete-pdf.route';
 
 export default new VirtualBrowser({
    autoInit: true,
-   endpoints: [ cvCreatePdfRoute ],
-   async onInit(virtualBrowser) {
+   endpoints: [ cvCreatePdfRoute, cvDeletePdfRoute ],
+   async onInit() {
       console.log('[virtual-browser] Virtual Browser service initialized successfully!');
    },
    onError(error) {

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -359,7 +359,7 @@ export default class CV extends CVSet {
       }
    }
 
-   static async delete(cv_id: number): Promise<boolean> {
+   static async delete(cv_id: number): Promise<CV[]> {
       if (!cv_id) {
          throw new ErrorDatabase('CV ID is required for deletion', 'CV_DELETE_ERROR');
       }
@@ -372,13 +372,13 @@ export default class CV extends CVSet {
             throw new ErrorDatabase('Failed to delete CV set', 'CV_SET_DELETE_ERROR');
          }
 
-         const deleteQuery = database.delete('curriculums_schema', 'cvs').where({ id: cv_id });
-         const { error: cvError } = await deleteQuery.exec();
+         const deleteQuery = database.delete('curriculums_schema', 'cvs').where({ id: cv_id }).returning();
+         const { data: deletedCVs = [], error: cvError } = await deleteQuery.exec();
          if (cvError) {
             throw new ErrorDatabase('Failed to delete CV', 'CV_DELETE_ERROR');
          }
 
-         return true;
+         return deletedCVs.map(cv => new CV(cv));
       } catch (error: any) {
          console.error('Error deleting CV:', error);
          throw new ErrorDatabase(error.message, error.code || 'CV_DELETE_ERROR');

--- a/src/database/tables/curriculums_schema/cvs.ts
+++ b/src/database/tables/curriculums_schema/cvs.ts
@@ -1,5 +1,6 @@
+import { CV } from '../../../database/models/curriculums_schema';
 import { locales } from '../../../app.config';
-import { sendToCreateCVPDF } from '../../../helpers/database.helper';
+import { sendToCreateCVPDF, sendToDeleteCVPDF } from '../../../helpers/database.helper';
 import Table from '../../../services/Database/models/Table';
 
 export default new Table({
@@ -26,6 +27,20 @@ export default new Table({
 
          locales.forEach((language_set) => {
             sendToCreateCVPDF({ cv_id: responseData.id, language_set });
+         });
+      },
+      async onAfterDelete(query) {
+         const responseData = query.firstRow;
+
+         if (!responseData) {
+            return;
+         }
+
+         const cv = new CV(responseData);
+
+         await cv.populateUser();
+         locales.forEach((language_set) => {
+            sendToDeleteCVPDF(responseData.id, language_set, cv.user?.name);
          });
       }
    }

--- a/src/helpers/database.helper.ts
+++ b/src/helpers/database.helper.ts
@@ -1,6 +1,10 @@
-import { CV } from '@/database/models/curriculums_schema';
+import { CV } from '../database/models/curriculums_schema';
 
 export async function sendToCreateCVPDF(params: Partial<CV>) {
    const { cv_id, language_set } = params;
    service.sendTo('/virtual-browser/cv-create-pdf', { cv_id, language_set });
+}
+
+export async function sendToDeleteCVPDF(cv_id: number, language_set: string, userFullName: string) {
+   service.sendTo('/virtual-browser/cv-delete-pdf', { cv_id, language_set, userFullName });
 }

--- a/src/helpers/parse.helper.ts
+++ b/src/helpers/parse.helper.ts
@@ -15,11 +15,19 @@ export function frontendURL(path: string, queryParams: Record<string, string | n
    return url.toString();
 }
 
-export function cvPdfPath(cv: Partial<CV>): string {
-   if (!cv?.user?.name) {
-      throw new Error('Invalid CV object');
+export function cvPdfPath(userFullName: string, cvId: number, languageSet: string): string {
+   if (!userFullName) {
+      throw new Error('Invalid userFullName provided');
    }
 
-   const userName = cv.user.name.replace(/ /g, '_');
-   return `pdf/cv/${userName}-CV_${cv.id}_${cv.language_set}.pdf`;
+   if (!cvId || typeof cvId !== 'number') {
+      throw new Error('Invalid cvId provided');
+   }
+
+   if (!languageSet || typeof languageSet !== 'string') {
+      throw new Error('Invalid languageSet provided');
+   }
+
+   const userName = userFullName.replace(/ /g, '_');
+   return `pdf/cv/${userName}-CV_${cvId}_${languageSet}.pdf`;
 }

--- a/src/services/Database/builders/SQL.ts
+++ b/src/services/Database/builders/SQL.ts
@@ -32,6 +32,7 @@ class SQL {
    protected values: any[];
    protected isAllowedNullWhere: boolean;
    protected queryType: string;
+   private _eventsData: Map<string, any>;
    public response: Result | null;
 
    /**
@@ -45,6 +46,7 @@ class SQL {
          throw new ErrorDatabase('A valid database instance with a query method is required.', 'DATABASE_INSTANCE_REQUIRED');
       }
 
+      this._eventsData = new Map();
       this.queryType = '';
       this.database = database;
       this.schemaName = schemaName;
@@ -81,6 +83,26 @@ class SQL {
 
       const [ firstRow ] = this.response.rows;
       return firstRow || null;
+   }
+
+   getEventData(key: string): any {
+      if (!this._eventsData.has(key)) {
+         return;
+      }
+
+      if (typeof key !== 'string' || !key.trim()) {
+         throw new ErrorDatabase('Invalid event name.', 'INVALID_EVENT_NAME');
+      }
+
+      return this._eventsData.get(key);
+   }
+
+   setEventData(key: string, data: any): void {
+      if (typeof key !== 'string' || !key.trim()) {
+         throw new ErrorDatabase('Invalid event name.', 'INVALID_EVENT_NAME');
+      }
+
+      this._eventsData.set(key, data);
    }
 
    /**

--- a/src/services/VirtualBrowser/VirtualBrowser.helpers.ts
+++ b/src/services/VirtualBrowser/VirtualBrowser.helpers.ts
@@ -9,3 +9,12 @@ export async function writeFile(filePath: string, data: Uint8Array): Promise<boo
       throw new ErrorVirtualBrowser(`Failed to write file at ${filePath}: ${error.message}`, error.code || 'FILE_WRITE_ERROR');
    }
 }
+
+export async function deleteFile(filePath: string): Promise<boolean> {
+   try {
+      await fs.promises.unlink(filePath);
+      return true;
+   } catch (error: any) {
+      throw new ErrorVirtualBrowser(`Failed to delete file at ${filePath}: ${error.message}`, error.code || 'FILE_DELETE_ERROR');
+   }
+}


### PR DESCRIPTION
## [FRCV-106] Description
This pull request introduces functionality to delete CV PDFs and includes several related improvements to the codebase. The changes span new endpoints, database enhancements, helper functions, and error handling. Below is a summary of the most important changes grouped by theme.

### New Endpoint for Deleting CV PDFs:
* Added a new endpoint `/virtual-browser/cv-delete-pdf` to handle the deletion of CV PDFs. It uses the `cvPdfPath` helper to determine the file path and the `deleteFile` utility to remove the file. Error handling is implemented for robust operation. 

### Database Enhancements:
* Updated the `CV` model's `delete` method to return the deleted CVs instead of a boolean. This uses the `database.delete` query with the `returning` clause to fetch deleted records.
* Introduced an `onAfterDelete` hook in the `cvs` table to trigger the deletion of associated CV PDFs after a CV is deleted. 

### Helper Functions:
* Refactored the `cvPdfPath` helper to accept explicit parameters (`userFullName`, `cvId`, and `languageSet`) instead of a `CV` object, improving reusability and clarity.
* Added a new `sendToDeleteCVPDF` function to facilitate communication with the `/virtual-browser/cv-delete-pdf` endpoint. 
* Introduced a `deleteFile` utility function to handle file deletion and error reporting. 

### Service Integration:
* Registered the new `cvDeletePdfRoute` endpoint in the `VirtualBrowser` service, ensuring it is initialized and available for use. 

### Database Query Enhancements:
* Added `setEventData` and `getEventData` methods to the `SQL` class to store and retrieve event-specific data during database operations.

[FRCV-106]: https://feliperamosdev.atlassian.net/browse/FRCV-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ