### PR TITLE
[FRCV-109] Implement defaultLocale on the code

### DIFF
--- a/src/containers/routes/virtual-browser/cv-create-pdf.route.ts
+++ b/src/containers/routes/virtual-browser/cv-create-pdf.route.ts
@@ -2,11 +2,12 @@ import { EventEndpoint } from '../../../services';
 import { cvPdfPath, frontendURL } from '../../../helpers/parse.helper';
 import { CV } from '../../../database/models/curriculums_schema';
 import service from '../../../containers/virtual-browser.service';
+import { defaultLocale } from '../../../app.config';
 
 export default new EventEndpoint({
    path: '/virtual-browser/cv-create-pdf',
    controller: async (params = {}, done = () => {}) => {
-      const { cv_id, language_set = 'en' } = params;
+      const { cv_id, language_set = defaultLocale } = params;
       let cv: CV | undefined;
 
       if (!cv_id) {

--- a/src/containers/routes/virtual-browser/cv-delete-pdf.route.ts
+++ b/src/containers/routes/virtual-browser/cv-delete-pdf.route.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../../app.config';
 import { cvPdfPath } from '../../../helpers/parse.helper';
 import { EventEndpoint } from '../../../services';
 import ErrorEventEndpoint from '../../../services/EventEndpoint/ErrorEventEndpoint';
@@ -6,7 +7,7 @@ import { deleteFile } from '../../../services/VirtualBrowser/VirtualBrowser.help
 export default new EventEndpoint({
    path: '/virtual-browser/cv-delete-pdf',
    controller: async (params = {}, done = () => {}) => {
-      const { cv_id, language_set = 'en', userFullName } = params;
+      const { cv_id, language_set = defaultLocale, userFullName } = params;
       
       try {
          const pdfPath = cvPdfPath(userFullName, cv_id, language_set);

--- a/src/database/models/companies_schema/Company/Company.ts
+++ b/src/database/models/companies_schema/Company/Company.ts
@@ -5,6 +5,7 @@ import { CompanySetup, CreateCompanyData } from './Company.types';
 import { CompanySetSetup } from '../CompanySet/CompanySet.types';
 import { Experience } from '../../experiences_schema';
 import { CV } from '../../curriculums_schema';
+import { defaultLocale } from '../../../../app.config';
 
 export default class Company extends CompanySet {
    public company_name: string;
@@ -102,7 +103,7 @@ export default class Company extends CompanySet {
       });
    }
 
-   static async getById(company_id: number, language_set: string = 'en'): Promise<Company> {
+   static async getById(company_id: number, language_set: string = defaultLocale): Promise<Company> {
       try {
          const companyQuery = database.select('companies_schema', 'company_sets');
    

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -7,6 +7,7 @@ import { CVSetup } from './CV.types';
 import database from '../../../../database';
 import { AdminUser } from '../../users_schema';
 import { AdminUserPublic } from '../../users_schema/AdminUser/AdminUser.types';
+import { defaultLocale } from '../../../../app.config';
 
 export default class CV extends CVSet {
    public title: string;
@@ -112,7 +113,7 @@ export default class CV extends CVSet {
          const [expIndex] = this.cv_experiences;
 
          if (typeof expIndex === 'number') {
-            this.cv_experiences = await Experience.getManyById(this.cv_experiences as number[], this.language_set || 'en');
+            this.cv_experiences = await Experience.getManyById(this.cv_experiences as number[], this.language_set || defaultLocale);
          }
 
          return this.cv_experiences as Experience[];
@@ -130,7 +131,7 @@ export default class CV extends CVSet {
       try {
          const [skillIndex] = this.cv_skills;
          if (typeof skillIndex === 'number') {
-            this.cv_skills = await Skill.getManyById(this.cv_skills as number[], this.language_set || 'en');
+            this.cv_skills = await Skill.getManyById(this.cv_skills as number[], this.language_set || defaultLocale);
          }
 
          return this.cv_skills as Skill[];
@@ -187,7 +188,7 @@ export default class CV extends CVSet {
       }
    }
 
-   static async getMaster(language_set: string = 'en'): Promise<CV | null> {
+   static async getMaster(language_set: string = defaultLocale): Promise<CV | null> {
       try {
          const user = await AdminUser.getMaster();
 
@@ -208,7 +209,7 @@ export default class CV extends CVSet {
       }
    }
 
-   static async getUserCVs(user_id: number, language_set: string = 'en', onlyMaster?: boolean): Promise<CV[]> {
+   static async getUserCVs(user_id: number, language_set: string = defaultLocale, onlyMaster?: boolean): Promise<CV[]> {
       try {
          const getQuery = database.select('curriculums_schema', 'cv_sets');
 
@@ -238,7 +239,7 @@ export default class CV extends CVSet {
       }
    }
 
-   static async getById(id: number, language_set: string = 'en'): Promise<CV | null> {
+   static async getById(id: number, language_set: string = defaultLocale): Promise<CV | null> {
       if (!id) {
          throw new ErrorDatabase('CV ID is required', 'CV_ID_REQUIRED');
       }

--- a/src/database/models/curriculums_schema/CVSet/CVSet.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.ts
@@ -21,7 +21,7 @@ export default class CVSet extends TableRow {
          summary = '',
          user_id,
          cv_id,
-         language_set = 'en'
+         language_set = defaultLocale
       } = setup || {};
       
       this.cv_id = cv_id;

--- a/src/database/models/experiences_schema/Experience/Experience.ts
+++ b/src/database/models/experiences_schema/Experience/Experience.ts
@@ -8,6 +8,7 @@ import { Skill } from '../../skills_schema';
 import { ExperienceSetSetup } from '../ExperienceSet/ExperienceSet.types';
 import { SkillSetup } from '../../skills_schema/Skill/Skill.types';
 import { CV } from '../../curriculums_schema';
+import { defaultLocale } from '../../../../app.config';
 
 export default class Experience extends ExperienceSet {
    public type: ExperienceType;
@@ -198,7 +199,7 @@ export default class Experience extends ExperienceSet {
       }
    }
 
-   static async getById(id: number, language_set: string = 'en'): Promise<Experience | null> {
+   static async getById(id: number, language_set: string = defaultLocale): Promise<Experience | null> {
       try {
          const query = database.select('experiences_schema', 'experience_sets');
          query.where({ experience_id: id, language_set });
@@ -262,7 +263,7 @@ export default class Experience extends ExperienceSet {
       }
    }
 
-   static async getManyById(ids: number[], language_set: string = 'en'): Promise<Experience[]> {
+   static async getManyById(ids: number[], language_set: string = defaultLocale): Promise<Experience[]> {
       try {
          const query = database.select('experiences_schema', 'experience_sets');
          query.where(ids.map(id => ({ experience_id: id, language_set })));

--- a/src/database/models/skills_schema/Skill/Skill.ts
+++ b/src/database/models/skills_schema/Skill/Skill.ts
@@ -4,6 +4,7 @@ import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import SkillSet from '../SkillSet/SkillSet';
 import { Experience } from '../../experiences_schema';
 import { CV } from '../../curriculums_schema';
+import { defaultLocale } from '../../../../app.config';
 
 export default class Skill extends SkillSet {
    public name: string;
@@ -130,7 +131,7 @@ export default class Skill extends SkillSet {
       }
    }
 
-   static async getSkillsByUserId(userId: number, language_set: string = 'en'): Promise<Skill[]> {
+   static async getSkillsByUserId(userId: number, language_set: string = defaultLocale): Promise<Skill[]> {
       try {
          const query = database.select('skills_schema', 'skill_sets');
          query.where({ user_id: userId, language_set });
@@ -147,7 +148,7 @@ export default class Skill extends SkillSet {
       }
    }
 
-   static async getById(skill_id: number, language_set: string = 'en'): Promise<Skill | null> {
+   static async getById(skill_id: number, language_set: string = defaultLocale): Promise<Skill | null> {
       try {
          const query = database.select('skills_schema', 'skill_sets');
 

--- a/src/database/models/skills_schema/SkillSet/SkillSet.ts
+++ b/src/database/models/skills_schema/SkillSet/SkillSet.ts
@@ -2,6 +2,7 @@ import TableRow from '../../../../services/Database/models/TableRow';
 import database from '../../../../database';
 import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import { SkillSetSetup } from './SkillSet.types';
+import { defaultLocale } from '../../../../app.config';
 
 export default class SkillSet extends TableRow {
    public skill_id: number;
@@ -12,7 +13,7 @@ export default class SkillSet extends TableRow {
    constructor (setup: SkillSetSetup) {
       super('skills_schema', 'skill_sets', setup);
 
-      const { user_id, skill_id, language_set = 'en', journey } = setup || {};
+      const { user_id, skill_id, language_set = defaultLocale, journey } = setup || {};
 
       this.skill_id = skill_id;
       this.language_set = language_set;

--- a/src/database/tables/companies_schema/company_sets.ts
+++ b/src/database/tables/companies_schema/company_sets.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../../app.config';
 import Table from '../../../services/Database/models/Table';
 
 export default new Table({
@@ -5,7 +6,7 @@ export default new Table({
    fields: [
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
-      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: 'en' },
+      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: defaultLocale },
       { name: 'description', type: 'TEXT' },
       { name: 'industry', type: 'VARCHAR(255)' },
       { name: 'company_id',

--- a/src/database/tables/experiences_schema/experience_sets.ts
+++ b/src/database/tables/experiences_schema/experience_sets.ts
@@ -1,7 +1,8 @@
 import ErrorDatabase from '../../../services/Database/ErrorDatabase';
 import Table from '../../../services/Database/models/Table';
-import { Experience, ExperienceSet } from '../../../database/models/experiences_schema';
+import { ExperienceSet } from '../../../database/models/experiences_schema';
 import { sendToCreateCVPDF } from '../../../helpers/database.helper';
+import { defaultLocale } from '../../../app.config';
 
 export default new Table({
    name: 'experience_sets',
@@ -10,7 +11,7 @@ export default new Table({
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'slug', type: 'VARCHAR(255)', notNull: true },
       { name: 'position', type: 'VARCHAR(50)', notNull: true },
-      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: 'en' },
+      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: defaultLocale },
       { name: 'summary', type: 'TEXT', notNull: true },
       { name: 'description', type: 'TEXT' },
       { name: 'responsibilities', type: 'TEXT' },

--- a/src/database/tables/skills_schema/skill_sets.ts
+++ b/src/database/tables/skills_schema/skill_sets.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../../app.config';
 import Table from '../../../services/Database/models/Table';
 
 export default new Table({
@@ -5,7 +6,7 @@ export default new Table({
    fields: [
       { name: 'id', primaryKey: true, autoIncrement: true },
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
-      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: 'en' },
+      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: defaultLocale },
       { name: 'journey', type: 'VARCHAR(255)' },
       { 
          name: 'user_id',

--- a/src/routes/company/create.route.ts
+++ b/src/routes/company/create.route.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../app.config';
 import { Company } from '../../database/models/companies_schema';
 import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
@@ -30,7 +31,7 @@ export default new Route({
             industry,
             description,
             location,
-            language_set: 'en',
+            language_set: defaultLocale,
             user_id: userId
          });
 

--- a/src/routes/curriculum/create-set.route.ts
+++ b/src/routes/curriculum/create-set.route.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../app.config';
 import CVSet from '../../database/models/curriculums_schema/CVSet/CVSet';
 import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
@@ -8,7 +9,7 @@ export default new Route({
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],
    controller: async (req, res) => {
-      const { cv_id, job_title, summary, language_set = 'en' } = req.body;
+      const { cv_id, job_title, summary, language_set = defaultLocale } = req.body;
       const userId = req.session?.user?.id || 1;
 
       if (!userId) {

--- a/src/routes/curriculum/public/cv_id.route.ts
+++ b/src/routes/curriculum/public/cv_id.route.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from "../../../app.config";
 import { CV } from "../../../database/models/curriculums_schema";
 import { Route } from "../../../services";
 import ErrorResponseServerAPI from "../../../services/ServerAPI/models/ErrorResponseServerAPI";
@@ -7,7 +8,7 @@ export default new Route({
    routePath: '/curriculum/public/:cv_id',
    controller: async (req, res) => {
       const { cv_id } = req.params || {};
-      const { language_set = 'en' } = req.query || {};
+      const { language_set = defaultLocale } = req.query || {};
 
       if (!cv_id) {
          new ErrorResponseServerAPI('CV ID is required', 400, 'CV_ID_REQUIRED').send(res);

--- a/src/routes/experience/experience_id.route.ts
+++ b/src/routes/experience/experience_id.route.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../app.config';
 import { Experience } from '../../database/models/experiences_schema';
 import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
@@ -7,7 +8,7 @@ export default new Route({
    routePath: '/experience/:experience_id',
    controller: async (req, res) => {
       const { experience_id } = req.params;
-      const { language_set = 'en' } = req.query;
+      const { language_set = defaultLocale } = req.query;
       const experienceId = parseInt(experience_id, 10);
 
       if (isNaN(experienceId) || experienceId < 0) {

--- a/src/routes/experience/public/user-experiences.route.ts
+++ b/src/routes/experience/public/user-experiences.route.ts
@@ -1,12 +1,13 @@
-import { Experience } from "../../../database/models/experiences_schema";
-import { Route } from "../../../services";
-import ErrorResponseServerAPI from "../../../services/ServerAPI/models/ErrorResponseServerAPI";
+import { defaultLocale } from '../../../app.config';
+import { Experience } from '../../../database/models/experiences_schema';
+import { Route } from '../../../services';
+import ErrorResponseServerAPI from '../../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
    method: 'GET',
    routePath: '/experience/public/user-experiences',
    controller: async (req, res) => {
-      const { language_set = 'en' } = req.query;
+      const { language_set = defaultLocale } = req.query;
 
       try {
          const masterExperiences: Experience[] = await Experience.getMasterUserPublic(language_set as string);

--- a/src/routes/skill/public/user-skills.route.ts
+++ b/src/routes/skill/public/user-skills.route.ts
@@ -1,12 +1,13 @@
-import { Skill } from "../../../database/models/skills_schema";
-import { Route } from "../../../services";
-import ErrorResponseServerAPI from "../../../services/ServerAPI/models/ErrorResponseServerAPI";
+import { defaultLocale } from '../../../app.config';
+import { Skill } from '../../../database/models/skills_schema';
+import { Route } from '../../../services';
+import ErrorResponseServerAPI from '../../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
    method: 'GET',
    routePath: '/skill/public/user-skills',
    controller: async (req, res) => {
-      const { language_set = 'en' } = req.query;
+      const { language_set = defaultLocale } = req.query;
 
       try {
          const masterUserSkills = await Skill.getMasterUserPublic(language_set as string);


### PR DESCRIPTION
## [FRCV-109] Description
This pull request standardizes the handling of the `language_set` parameter across the codebase by replacing the hardcoded default value `'en'` with the configurable `defaultLocale` from `app.config`. This improves maintainability and flexibility for supporting multiple locales. Below is a summary of the most important changes grouped by theme:

### Updates to Routes

* Replaced the default `'en'` value for the `language_set` parameter with `defaultLocale` in various route controllers, including `cv-create-pdf`, `cv-delete-pdf`, `company/create`, `curriculum/create-set`, `curriculum/public/cv_id`, and `experience/experience_id` routes.

### Updates to Database Models

* Updated model classes (`Company`, `CV`, `Experience`, `Skill`, and `SkillSet`) to use `defaultLocale` as the default for `language_set` in both constructors and static methods like `getById`, `getManyById`, and others.

### Updates to Database Table Definitions

* Modified table definitions for `company_sets`, `experience_sets`, and `skill_sets` to set `defaultLocale` as the default value for the `language_set` column instead of `'en'`.

### General Codebase Improvements

* Added imports for `defaultLocale` in all affected files to ensure consistency and centralized configuration. 

These changes collectively enhance the codebase's ability to adapt to different locales by leveraging a single configuration point for default language settings.

[FRCV-109]: https://feliperamosdev.atlassian.net/browse/FRCV-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ