### PR TITLE
[FRCV-110] Prevent duplicate master CV

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -159,7 +159,7 @@ export default class CV extends CVSet {
       }
    }
 
-   async save(props?: CVSetup): Promise<CVSet> {
+   async save(props?: CVSetup): Promise<CV> {
       let processing;
 
       try {


### PR DESCRIPTION
## [FRCV-110] Description
This pull request includes updates to the `CV` model and the curriculum creation route to enhance functionality and fix type inconsistencies. The most important changes involve updating the `save` method's return type, adding a new property to the curriculum creation payload, and implementing logic for setting a master CV.

### Updates to the `CV` model:

* The `save` method in `src/database/models/curriculums_schema/CV/CV.ts` was updated to return a `CV` instance instead of a `CVSet`, ensuring type consistency with the class definition.

### Enhancements to the curriculum creation route:

* The `experience_time` property was added to the `CVSetup` payload in `src/routes/curriculum/create.route.ts` to support additional curriculum data.
* The `experience_time` property is now included when creating a new `CV` instance, and the `is_master` property was removed from the object passed to the `CV` constructor.
* Logic was added to set a master CV when the `is_master` flag is true, including error handling for failures in `CV.setUserMasterCV`.

[FRCV-110]: https://feliperamosdev.atlassian.net/browse/FRCV-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ