### PR TITLE
[FRD-130] Add sub_title field to CVSet model and schema

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -160,8 +160,6 @@ export default class CV extends CVSet {
    }
 
    async save(props?: CVSetup): Promise<CV> {
-      let processing;
-
       try {
          const { data = [], error } = await database.insert('curriculums_schema', 'cvs').data(this.toSave).returning().exec();
          const [savedCV] = data;
@@ -174,7 +172,6 @@ export default class CV extends CVSet {
             throw new ErrorDatabase('No CV saved', 'CV_SAVE_NO_DATA');
          }
 
-         processing = savedCV;
          const cvData = { ...this, ...props, cv_id: savedCV.id };
          const newCVSet = await CVSet.createSet(cvData as CVSetSetup);
 

--- a/src/database/models/curriculums_schema/CVSet/CVSet.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.ts
@@ -9,6 +9,7 @@ import { defaultLocale } from '../../../../app.config';
 export default class CVSet extends TableRow {
    public user_id?: number | null;
    public job_title?: string;
+   public sub_title?: string;
    public summary?: string;
    public cv_id?: number;
    public language_set: string;
@@ -19,6 +20,7 @@ export default class CVSet extends TableRow {
 
       const {
          job_title = '',
+         sub_title = '',
          summary = '',
          user_id,
          cv_id,
@@ -28,19 +30,21 @@ export default class CVSet extends TableRow {
       this.cv_id = cv_id;
       this.language_set = language_set;
       this.job_title = job_title;
+      this.sub_title = sub_title;
       this.summary = summary;
       this.user_id = user_id;
       this.user = new AdminUser(setup);
    }
 
    static async createSet(setup: CVSetSetup): Promise<CVSet> {
-      const { cv_id, user_id, job_title, summary, language_set } = setup || {};
+      const { cv_id, user_id, job_title, sub_title, summary, language_set } = setup || {};
 
       try {
          const { data = [], error } = await database.insert('curriculums_schema', 'cv_sets').data({
             cv_id,
             user_id,
             job_title,
+            sub_title,
             summary,
             language_set
          }).returning().exec();

--- a/src/database/models/curriculums_schema/CVSet/CVSet.types.ts
+++ b/src/database/models/curriculums_schema/CVSet/CVSet.types.ts
@@ -1,5 +1,6 @@
 export interface CVSetSetup {
    job_title: string;
+   sub_title: string;
    summary: string;
    user_id?: number;
    cv_id?: number;

--- a/src/database/tables/curriculums_schema/cv_sets.ts
+++ b/src/database/tables/curriculums_schema/cv_sets.ts
@@ -8,6 +8,7 @@ export default new Table({
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'job_title', type: 'VARCHAR(255)' },
+      { name: 'sub_title', type: 'VARCHAR(255)' },
       { name: 'summary', type: 'TEXT' },
       { name: 'language_set', type: 'VARCHAR(2)', notNull: true },
       { name: 'user_id', type: 'INTEGER', notNull: true, relatedField: {


### PR DESCRIPTION
## [FRD-130] Description
This pull request introduces changes to the `CV` and `CVSet` models to enhance functionality and improve code clarity. The most significant updates include the addition of a new `sub_title` field to the `CVSet` model and the removal of unused variables in the `CV` model's `save` method.

### Enhancements to `CVSet` model:

* Added a new `sub_title` field to the `CVSet` class, including updates to its constructor and the `createSet` method to handle this field. (`src/database/models/curriculums_schema/CVSet/CVSet.ts`: [[1]](diffhunk://#diff-2237f6a296536586bb1c0355908319ae6d56e0726e135ef696f8a26f9a6a66ccR12) [[2]](diffhunk://#diff-2237f6a296536586bb1c0355908319ae6d56e0726e135ef696f8a26f9a6a66ccR23) [[3]](diffhunk://#diff-2237f6a296536586bb1c0355908319ae6d56e0726e135ef696f8a26f9a6a66ccR33-R47)
* Updated the `CVSetSetup` interface to include the `sub_title` field. (`src/database/models/curriculums_schema/CVSet/CVSet.types.ts`: [src/database/models/curriculums_schema/CVSet/CVSet.types.tsR3](diffhunk://#diff-130cff4ccd5b755f69eec48e08f8bb8464bf683b34597ba29b8461f8f712bbfeR3))
* Modified the database schema for the `cv_sets` table to add a `sub_title` column. (`src/database/tables/curriculums_schema/cv_sets.ts`: [src/database/tables/curriculums_schema/cv_sets.tsR11](diffhunk://#diff-9640d12e81b4f523445a131a8534d94120935fc4b39876f933e9c992b1f70594R11))

### Code cleanup in `CV` model:

* Removed the unused `processing` variable from the `save` method in the `CV` class, simplifying the code. (`src/database/models/curriculums_schema/CV/CV.ts`: [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL163-L164) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL177)