### PR TITLE
[FRCV-112] Fixing Docker build error

### DIFF
--- a/src/routes/curriculum/create-set.route.ts
+++ b/src/routes/curriculum/create-set.route.ts
@@ -9,7 +9,7 @@ export default new Route({
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],
    controller: async (req, res) => {
-      const { cv_id, job_title, summary, language_set = defaultLocale } = req.body;
+      const { cv_id, job_title, sub_title, summary, language_set = defaultLocale } = req.body;
       const userId = req.session?.user?.id || 1;
 
       if (!userId) {
@@ -26,6 +26,7 @@ export default new Route({
          const newSet = await CVSet.createSet({
             cv_id,
             job_title,
+            sub_title,
             summary,
             user_id: userId,
             language_set

--- a/src/routes/curriculum/create.route.ts
+++ b/src/routes/curriculum/create.route.ts
@@ -10,7 +10,7 @@ export default new Route({
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],
    controller: async (req: Request, res: Response) => {
-      const { title, notes, cv_experiences = [], cv_skills = [], summary, is_master, job_title, experience_time }: CVSetup = req.body;
+      const { title, notes, cv_experiences = [], cv_skills = [], summary, is_master, job_title, sub_title, experience_time }: CVSetup = req.body;
       const userId = req.session?.user?.id;
 
       if (!userId) {
@@ -32,6 +32,7 @@ export default new Route({
             cv_skills,
             summary,
             job_title,
+            sub_title,
             user_id: userId
          });
 


### PR DESCRIPTION
## [FRCV-112] Description
This pull request introduces a new `sub_title` field to the curriculum creation and set creation routes, ensuring the API can handle and persist this additional data. The changes affect the request payloads and the corresponding database operations.

### Changes to curriculum creation routes:

* [`src/routes/curriculum/create-set.route.ts`](diffhunk://#diff-4e0643b0aacc16429b43c6588ea19309eda5f93ac111810f24a1b6a7c4c99251L12-R12): Added `sub_title` to the destructured request body and included it in the `CVSet.createSet` method call to persist the subtitle when creating a curriculum set. [[1]](diffhunk://#diff-4e0643b0aacc16429b43c6588ea19309eda5f93ac111810f24a1b6a7c4c99251L12-R12) [[2]](diffhunk://#diff-4e0643b0aacc16429b43c6588ea19309eda5f93ac111810f24a1b6a7c4c99251R29)

* [`src/routes/curriculum/create.route.ts`](diffhunk://#diff-50e0775b496610b4f2821aa5dc2ba10c1683fdca77c8d724141bc1c30e3c4dd5L13-R13): Added `sub_title` to the destructured request body and passed it to the curriculum creation logic to support subtitles in the main curriculum creation process. [[1]](diffhunk://#diff-50e0775b496610b4f2821aa5dc2ba10c1683fdca77c8d724141bc1c30e3c4dd5L13-R13) [[2]](diffhunk://#diff-50e0775b496610b4f2821aa5dc2ba10c1683fdca77c8d724141bc1c30e3c4dd5R35)

[FRCV-112]: https://feliperamosdev.atlassian.net/browse/FRCV-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ