### PR TITLE
[FRCV-115] Languages Schema/Tables/Models

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -5,6 +5,7 @@ import experiences_schema from './schemas/experiences_schema';
 import skills_schema from './schemas/skills_schema';
 import users_schema from './schemas/users_schema';
 import curriculums_schema from './schemas/curriculums_schema';
+import languages_schema from './schemas/languages_schema';
 
 const database = new PostgresDB({
    dbName: process.env.POSTGRES_DB,
@@ -17,6 +18,7 @@ const database = new PostgresDB({
       skills_schema,
       companies_schema,
       experiences_schema,
+      languages_schema,
       curriculums_schema
    ]
 });

--- a/src/database/models/languages_schema/Language/Language.ts
+++ b/src/database/models/languages_schema/Language/Language.ts
@@ -1,0 +1,27 @@
+import LanguageSet from '../LanguageSet/LanguageSet';
+import { LanguageLevel, LanguageSetup } from './Language.types';
+
+class Language extends LanguageSet {
+   public locale_code: string;
+   public reading_level: LanguageLevel;
+   public listening_level: LanguageLevel;
+   public writing_level: LanguageLevel;
+   public speaking_level: LanguageLevel;
+
+   constructor (setup: LanguageSetup) {
+      super(setup, 'languages_schema', 'languages');
+      const { locale_code, reading_level, listening_level, writing_level, speaking_level } = setup || {};
+
+      if (!locale_code || !reading_level || !listening_level || !writing_level || !speaking_level) {
+         throw new Error('Missing required fields for Language');
+      }
+
+      this.locale_code = locale_code;
+      this.reading_level = reading_level;
+      this.listening_level = listening_level;
+      this.writing_level = writing_level;
+      this.speaking_level = speaking_level;
+   }
+}
+
+export default Language;

--- a/src/database/models/languages_schema/Language/Language.types.ts
+++ b/src/database/models/languages_schema/Language/Language.types.ts
@@ -1,0 +1,11 @@
+import { LanguageSetSetup } from '../LanguageSet/LanguageSet.types';
+
+export type LanguageLevel = 'beginner' | 'intermediate' | 'advanced' | 'native';
+
+export interface LanguageSetup extends LanguageSetSetup {
+   locale_code: string;
+   reading_level: LanguageLevel;
+   listening_level: LanguageLevel;
+   writing_level: LanguageLevel;
+   speaking_level : LanguageLevel;
+}

--- a/src/database/models/languages_schema/LanguageSet/LanguageSet.ts
+++ b/src/database/models/languages_schema/LanguageSet/LanguageSet.ts
@@ -1,0 +1,22 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { LanguageSetSetup } from './LanguageSet.types';
+
+class LanguageSet extends TableRow {
+   public language_set: string;
+   public display_name: string;
+
+   constructor (setup: LanguageSetSetup, schemaName: string = 'languages_schema', tableName: string = 'language_sets') {
+      super(schemaName, tableName, setup);
+      const { language_set, display_name } = setup || {};
+
+      if (!language_set || !display_name) {
+         throw new Error('Missing required fields for LanguageSet');
+      }
+
+      this.language_set = language_set;
+      this.display_name = display_name;
+   }
+
+}
+
+export default LanguageSet;

--- a/src/database/models/languages_schema/LanguageSet/LanguageSet.types.ts
+++ b/src/database/models/languages_schema/LanguageSet/LanguageSet.types.ts
@@ -1,0 +1,4 @@
+export interface LanguageSetSetup {
+   language_set: string;
+   display_name?: string;
+}

--- a/src/database/models/languages_schema/LanguageSet/LanguageSet.types.ts
+++ b/src/database/models/languages_schema/LanguageSet/LanguageSet.types.ts
@@ -1,4 +1,4 @@
 export interface LanguageSetSetup {
    language_set: string;
-   display_name?: string;
+   display_name: string;
 }

--- a/src/database/models/languages_schema/index.ts
+++ b/src/database/models/languages_schema/index.ts
@@ -1,0 +1,2 @@
+export { default as Language } from './Language/Language';
+export { default as LanguageSet } from './LanguageSet/LanguageSet';

--- a/src/database/schemas/languages_schema.ts
+++ b/src/database/schemas/languages_schema.ts
@@ -1,0 +1,8 @@
+import Schema from '../../services/Database/models/Schema';
+import languages from '../tables/languages_schema/languages';
+import language_sets from '../tables/languages_schema/language_sets';
+
+export default new Schema({
+   name: 'languages_schema',
+   tables: [ languages, language_sets ]
+});

--- a/src/database/tables/languages_schema/language_sets.ts
+++ b/src/database/tables/languages_schema/language_sets.ts
@@ -1,0 +1,12 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'language_sets',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'language_set', type: 'VARCHAR(2)', notNull: true },
+      { name: 'display_name', type: 'VARCHAR(100)' },
+   ]
+});

--- a/src/database/tables/languages_schema/language_sets.ts
+++ b/src/database/tables/languages_schema/language_sets.ts
@@ -7,6 +7,6 @@ export default new Table({
       { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
       { name: 'language_set', type: 'VARCHAR(2)', notNull: true },
-      { name: 'display_name', type: 'VARCHAR(100)' },
+      { name: 'display_name', type: 'VARCHAR(100)', notNull: true },
    ]
 });

--- a/src/database/tables/languages_schema/languages.ts
+++ b/src/database/tables/languages_schema/languages.ts
@@ -1,0 +1,15 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'languages',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'locale_code', type: 'VARCHAR(2)', notNull: true },
+      { name: 'reading_level', type: 'VARCHAR(50)', notNull: true },
+      { name: 'listening_level', type: 'VARCHAR(50)', notNull: true },
+      { name: 'writing_level', type: 'VARCHAR(50)', notNull: true },
+      { name: 'speaking_level', type: 'VARCHAR(50)', notNull: true },
+   ]
+});


### PR DESCRIPTION
## [FRCV-115] Description
This pull request introduces a new `languages_schema` to the database, adding support for storing and managing language proficiency information. It includes new schema definitions, table models, and corresponding TypeScript classes and types for both languages and language sets. The database initialization is updated to include this new schema.

**Database schema additions:**

* Added new `languages_schema` with `languages` and `language_sets` tables, including their field definitions. (`src/database/schemas/languages_schema.ts`, `src/database/tables/languages_schema/languages.ts`, `src/database/tables/languages_schema/language_sets.ts`) [[1]](diffhunk://#diff-c71c8aaee7768445066bf46246e45322602634e962d6878d2826815e304cb67cR1-R8) [[2]](diffhunk://#diff-c56b78d3bfbc9d13749ad4b87a97923aa0c26090b6cda58ada212ac0bae047fbR1-R15) [[3]](diffhunk://#diff-1e6a0d69f4a248a0b23ec088e5fe3aa068f7b0888418a607687a08da7d97fa99R1-R12)
* Updated database initialization to import and register the new `languages_schema`. (`src/database/index.ts`) [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R8) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R21)

**Model and type definitions:**

* Implemented `Language` and `LanguageSet` classes to represent rows in the new tables, with validation for required fields. (`src/database/models/languages_schema/Language/Language.ts`, `src/database/models/languages_schema/LanguageSet/LanguageSet.ts`) [[1]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R1-R27) [[2]](diffhunk://#diff-ed77a5b97b84c07e7803c3d031471ee435cc016c7851772a6c7509f53eed6b18R1-R22)
* Defined TypeScript types for language levels and setup interfaces for both models. (`src/database/models/languages_schema/Language/Language.types.ts`, `src/database/models/languages_schema/LanguageSet/LanguageSet.types.ts`) [[1]](diffhunk://#diff-69036839a4cbc8b60ac8cf2b54084aa7b337ddd25191e82bb6a6c6902328d378R1-R11) [[2]](diffhunk://#diff-1f64fc9c50f2c51df9de26af388c777ca05011ecba0af1c935d17f5cc5f146adR1-R4)
* Exported the new models for use elsewhere in the codebase. (`src/database/models/languages_schema/index.ts`)

[FRCV-115]: https://feliperamosdev.atlassian.net/browse/FRCV-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ