### PR TITLE
[FRCV-116] Language Routes

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -34,6 +34,11 @@ import companyUpdateSet from '../routes/company/update-set.route';
 import companyGet from '../routes/company/company_id.route';
 import companyDelete from '../routes/company/delete.route';
 
+import languageCreate from '../routes/language/create.route';
+import languageGet from '../routes/language/language_id.route';
+import languageUpdate from '../routes/language/update.route';
+import languageDelete from '../routes/language/delete.route';
+
 import curriculumCreate from '../routes/curriculum/create.route';
 import curriculumCreateSet from '../routes/curriculum/create-set.route';
 import curriculumGet from '../routes/curriculum/cv_id.route';
@@ -109,6 +114,10 @@ global.service = new ServerAPI({
       companyQuery,
       companyGet,
       companyDelete,
+      languageCreate,
+      languageGet,
+      languageUpdate,
+      languageDelete,
       curriculumCreate,
       curriculumCreateSet,
       curriculumUpdate,

--- a/src/database/models/languages_schema/Language/Language.ts
+++ b/src/database/models/languages_schema/Language/Language.ts
@@ -1,6 +1,11 @@
-import ErrorDatabase from '@/services/Database/ErrorDatabase';
+import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import TableRow from '../../../../services/Database/models/TableRow';
-import { LanguageLevel, LanguageSetup } from './Language.types';
+import database from '../../../../database';
+
+import type {
+   LanguageLevel,
+   LanguageSetup
+} from './Language.types';
 
 class Language extends TableRow {
    public default_name: string;
@@ -10,12 +15,13 @@ class Language extends TableRow {
    public listening_level: LanguageLevel;
    public writing_level: LanguageLevel;
    public speaking_level: LanguageLevel;
+   public language_user_id: string;
 
    constructor (setup: LanguageSetup) {
       super('languages_schema', 'languages', setup);
-      const { default_name, local_name, locale_code, reading_level, listening_level, writing_level, speaking_level } = setup || {};
+      const { default_name, local_name, locale_code, reading_level, listening_level, writing_level, speaking_level, language_user_id } = setup || {};
 
-      if (!default_name || !local_name || !locale_code || !reading_level || !listening_level || !writing_level || !speaking_level) {
+      if (!default_name || !local_name || !locale_code || !reading_level || !listening_level || !writing_level || !speaking_level || !language_user_id) {
          throw new ErrorDatabase('All fields are required for Language', 'LANGUAGE_REQUIRED_FIELDS');
       }
 
@@ -26,6 +32,94 @@ class Language extends TableRow {
       this.listening_level = listening_level;
       this.writing_level = writing_level;
       this.speaking_level = speaking_level;
+      this.language_user_id = language_user_id;
+   }
+
+   toObject() {
+      return {
+         id: this.id,
+         created_at: this.created_at,
+         updated_at: this.updated_at,
+         default_name: this.default_name,
+         local_name: this.local_name,
+         locale_code: this.locale_code,
+         reading_level: this.reading_level,
+         listening_level: this.listening_level,
+         writing_level: this.writing_level,
+         speaking_level: this.speaking_level,
+         language_user_id: this.language_user_id
+      };
+   }
+
+   async save(): Promise<Language | null> {
+      try {
+         const { data = [], error } = await database.insert(this.schemaName, this.tableName).data(this.toObject()).returning().exec();
+         const [ created ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to save Language', 'LANGUAGE_SAVE_FAILED');
+         }
+
+         if (!created) {
+            throw new ErrorDatabase('Failed to create Language', 'LANGUAGE_CREATION_FAILED');
+         }
+
+         return new Language(created);
+      } catch (error) {
+         throw new ErrorDatabase('Failed to save Language', 'LANGUAGE_SAVE_FAILED');
+      }
+   }
+
+   static async findById(language_id: number): Promise<Language | null> {
+      try {
+         const { data = [], error } = await database.select('languages_schema', 'languages').where({ id: language_id }).exec();
+         const [ found ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to find Language', 'LANGUAGE_FIND_FAILED');
+         }
+
+         if (!found) {
+            return null;
+         }
+
+         return new Language(found);
+      } catch (error) {
+         throw new ErrorDatabase('Failed to find Language', 'LANGUAGE_FIND_FAILED');
+      }
+   }
+
+   static async update(language_id: number, updates: Partial<LanguageSetup>): Promise<Language | null> {
+      try {
+         const { data = [], error } = await database.update('languages_schema', 'languages').set(updates).where({ id: language_id }).returning().exec();
+         const [ updated ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to update Language', 'LANGUAGE_UPDATE_FAILED');
+         }
+
+         if (!updated) {
+            return null;
+         }
+
+         return new Language(updated);
+      } catch (error) {
+         throw new ErrorDatabase('Failed to update Language', 'LANGUAGE_UPDATE_FAILED');
+      }
+   }
+
+   static async delete(language_id: number): Promise<boolean> {
+      try {
+         const { error } = await database.delete('languages_schema', 'languages').where({ id: language_id }).exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to delete Language', 'LANGUAGE_DELETE_FAILED');
+         }
+
+         return true;
+      } catch (error) {
+         throw new ErrorDatabase('Failed to delete Language', 'LANGUAGE_DELETE_FAILED');
+      }
    }
 }
 

--- a/src/database/models/languages_schema/Language/Language.types.ts
+++ b/src/database/models/languages_schema/Language/Language.types.ts
@@ -8,4 +8,5 @@ export interface LanguageSetup {
    listening_level: LanguageLevel;
    writing_level: LanguageLevel;
    speaking_level: LanguageLevel;
+   language_user_id: string;
 }

--- a/src/database/tables/languages_schema/languages.ts
+++ b/src/database/tables/languages_schema/languages.ts
@@ -13,5 +13,15 @@ export default new Table({
       { name: 'listening_level', type: 'VARCHAR(50)', notNull: true },
       { name: 'writing_level', type: 'VARCHAR(50)', notNull: true },
       { name: 'speaking_level', type: 'VARCHAR(50)', notNull: true },
+      {
+         name: 'language_user_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            field: 'id',
+            schema: 'users_schema',
+            table: 'admin_users'
+         }
+      }
    ]
 });

--- a/src/routes/language/create.route.ts
+++ b/src/routes/language/create.route.ts
@@ -1,0 +1,34 @@
+import { Language } from '../../database/models/languages_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/language/create',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const body = req.body || {};
+      const userId = req.session?.user?.id || 1;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User not authenticated', 401, 'USER_NOT_AUTHENTICATED').send(res);
+         return;
+      }
+
+      try {
+         const language = new Language({ ...body, language_user_id: userId });
+         const saved = await language.save();
+
+         if (!saved) {
+            new ErrorResponseServerAPI('Failed to create language', 400, 'LANGUAGE_CREATION_FAILED').send(res);
+            return;
+         }
+
+         res.status(200).send(saved);
+      } catch (error: any) {
+         new ErrorResponseServerAPI(error.message, 500, error.code || 'INTERNAL_SERVER_ERROR').send(res);
+         return;
+      }
+   }
+});

--- a/src/routes/language/delete.route.ts
+++ b/src/routes/language/delete.route.ts
@@ -1,0 +1,32 @@
+import { Language } from '../../database/models/languages_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/language/delete',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const { language_id } = req.body || {};
+
+      if (!language_id) {
+         new ErrorResponseServerAPI('Language ID is required', 400, 'REQUIRED_LANGUAGE_ID').send(res);
+         return;
+      }
+
+      try {
+         const deleted = await Language.delete(language_id);
+
+         if (!deleted) {
+            new ErrorResponseServerAPI('Failed to delete Language', 400, 'LANGUAGE_DELETE_FAILED').send(res);
+            return;
+         }
+
+         res.status(200).send(deleted);
+      } catch (error: any) {
+         new ErrorResponseServerAPI(error.message, 500, error.code || 'INTERNAL_SERVER_ERROR').send(res);
+         return;
+      }
+   }
+});

--- a/src/routes/language/language_id.route.ts
+++ b/src/routes/language/language_id.route.ts
@@ -1,0 +1,33 @@
+import { Route } from '../../services';
+import Language from '../../database/models/languages_schema/Language/Language';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/language/:language_id',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const { language_id } = req.params || {};
+      const languageId = Number(language_id);
+
+      if (isNaN(languageId)) {
+         new ErrorResponseServerAPI('Invalid language ID', 400, 'INVALID_LANGUAGE_ID').send(res);
+         return;
+      }
+
+      try {
+         const language = await Language.findById(languageId);
+
+         if (!language) {
+            new ErrorResponseServerAPI('Language not found', 404, 'LANGUAGE_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(language.toObject());
+      } catch (error: any) {
+         new ErrorResponseServerAPI(error.message, 500, error.code || 'INTERNAL_SERVER_ERROR').send(res);
+         return;
+      }
+   }
+})

--- a/src/routes/language/update.route.ts
+++ b/src/routes/language/update.route.ts
@@ -1,0 +1,33 @@
+import { Language } from '../../database/models/languages_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/language/update',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const { language_id, updates } = req.body || {};
+      const languageId = Number(language_id);
+
+      if (isNaN(languageId)) {
+         new ErrorResponseServerAPI('Invalid language ID', 400, 'INVALID_LANGUAGE_ID').send(res);
+         return;
+      }
+
+      try {
+         const language = await Language.update(languageId, updates);
+
+         if (!language) {
+            new ErrorResponseServerAPI('Language not found', 404, 'LANGUAGE_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(language);
+      } catch (error: any) {
+         new ErrorResponseServerAPI(error.message, 500, error.code || 'INTERNAL_SERVER_ERROR').send(res);
+         return;
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-116] Description
This pull request introduces full CRUD (Create, Read, Update, Delete) support for managing languages in the system. It adds a new `Language` model, updates the database schema, and implements corresponding API routes for language management. The changes ensure that each language record is associated with a user and that all necessary validation and error handling are in place.

**API Enhancements:**

- Added four new API routes for languages: create, get by ID, update, and delete, and registered them in the API server (`api-server.service.ts`). [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR37-R41) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR117-R120) [[3]](diffhunk://#diff-e5c5a29ed43327f55ec553043999eb89df15ee45b151f7f11193c27120bf2c2eR1-R34) [[4]](diffhunk://#diff-983e5cb45c76bff79fb9d2a45c8bba4c8735cfc1377a466c9c8ef9660c0ad4b0R1-R33) [[5]](diffhunk://#diff-dc0bb7dd03d7cddab54e6eab5658df6e121373a84776da7879a5adbb772d630fR1-R33) [[6]](diffhunk://#diff-7ecaed6f7d5637a652ceb9342538b55cd71c8776b507e5c19aa1cbca28af2179R1-R32)

**Database & Model Changes:**

- Updated the `languages` table schema to include a required `language_user_id` field with a foreign key to `admin_users`.
- Extended the `Language` model (`Language.ts` and `Language.types.ts`) with the new `language_user_id` property and implemented methods for saving, finding, updating, and deleting language records. [[1]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2L1-R8) [[2]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R18-R24) [[3]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R35-R122) [[4]](diffhunk://#diff-69036839a4cbc8b60ac8cf2b54084aa7b337ddd25191e82bb6a6c6902328d378R11)

**Validation & Error Handling:**

- Added comprehensive validation and error handling in all language-related API controllers to ensure robust responses and meaningful error messages. [[1]](diffhunk://#diff-e5c5a29ed43327f55ec553043999eb89df15ee45b151f7f11193c27120bf2c2eR1-R34) [[2]](diffhunk://#diff-983e5cb45c76bff79fb9d2a45c8bba4c8735cfc1377a466c9c8ef9660c0ad4b0R1-R33) [[3]](diffhunk://#diff-dc0bb7dd03d7cddab54e6eab5658df6e121373a84776da7879a5adbb772d630fR1-R33) [[4]](diffhunk://#diff-7ecaed6f7d5637a652ceb9342538b55cd71c8776b507e5c19aa1cbca28af2179R1-R32)