### PR TITLE
[FRCV-118] Route /user/languages

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -51,6 +51,7 @@ import curriculumPublicGet from '../routes/curriculum/public/cv_id.route';
 
 import userUpdate from '../routes/user/update.route';
 import userMasterCV from '../routes/user/master-cv.route';
+import userLanguages from '../routes/user/languages.route';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.replace(/ /g, '').split(',') : undefined;
@@ -128,7 +129,8 @@ global.service = new ServerAPI({
       curriculumDelete,
       curriculumPublicGet,
       userUpdate,
-      userMasterCV
+      userMasterCV,
+      userLanguages
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/users_schema/AdminUser/AdminUser.ts
+++ b/src/database/models/users_schema/AdminUser/AdminUser.ts
@@ -3,6 +3,7 @@ import TableRow from '../../../../services/Database/models/TableRow';
 import database from '../../..';
 import { AdminUserPublic, CreateUserProps, UserRoles } from './AdminUser.types';
 import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
+import { Language } from '../../languages_schema';
 
 const PUBLIC_FIELDS = [
    'id',
@@ -278,6 +279,23 @@ export default class AdminUser extends TableRow {
          return new AdminUser(user);
       } catch (error: any) {
          throw new ErrorDatabase(error.message, error.code || 'USER_UPDATE_ERROR');
+      }
+   }
+
+   static async getLanguages(userId: number): Promise<Language[]> {
+      if (!userId) {
+         throw new Error('User ID is required to fetch languages.');
+      }
+
+      try {
+         const query = database.select('languages_schema', 'languages');
+
+         query.where({ language_user_id: userId });
+         const { data = [] } = await query.exec();
+
+         return data.map(item => new Language(item));
+      } catch (error: any) {
+         throw new Error(`Fetching user languages failed: ${error.message}`);
       }
    }
 }

--- a/src/database/models/users_schema/AdminUser/AdminUser.ts
+++ b/src/database/models/users_schema/AdminUser/AdminUser.ts
@@ -295,7 +295,7 @@ export default class AdminUser extends TableRow {
 
          return data.map(item => new Language(item));
       } catch (error: any) {
-         throw new Error(`Fetching user languages failed: ${error.message}`);
+         throw new ErrorDatabase(`Fetching user languages failed: ${error.message}`, 'USER_LANGUAGES_FETCH_ERROR');
       }
    }
 }

--- a/src/routes/user/languages.route.ts
+++ b/src/routes/user/languages.route.ts
@@ -1,0 +1,31 @@
+import { AdminUser } from '../../database/models/users_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/user/languages',
+   useAuth: true,
+   allowedRoles: ['master', 'admin'],
+   controller: async (req, res) => {
+      const userId = req.session.user?.id;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User not authenticated', 401, 'Unauthorized').send(res);
+         return;
+      }
+
+      try {
+         const languages = await AdminUser.getLanguages(userId);
+
+         if (!languages) {
+            new ErrorResponseServerAPI('No languages found for the user', 404, 'Not Found').send(res);
+            return;
+         }
+
+         res.status(200).send(languages);
+      } catch (error: any) {
+         new ErrorResponseServerAPI(error.message, 500, error.code || 'Internal Server Error').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-118] Description
This pull request introduces a new API endpoint to allow authenticated users with the appropriate roles to retrieve their associated languages. The changes involve adding a new route, updating the server to register this route, and implementing the necessary logic in the `AdminUser` model to fetch user languages.

**New API endpoint for user languages:**

* Added a new route `user/languages.route.ts` that defines a GET endpoint at `/user/languages`, requiring authentication and allowing only users with `master` or `admin` roles. The endpoint returns the languages associated with the authenticated user.
* Registered the new `userLanguages` route in the API server by importing it and including it in the server's route list in `api-server.service.ts`. [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR54) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL131-R133)

**Model enhancements:**

* Added a static method `getLanguages` to the `AdminUser` model, which retrieves languages for a given user by querying the `languages_schema` table and mapping the results to `Language` instances.
* Imported the `Language` model into `AdminUser.ts` to support the new method.

[FRCV-118]: https://feliperamosdev.atlassian.net/browse/FRCV-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ