### PR TITLE
[FRCV-120] Educations Schema, Tables and Models

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,6 +6,7 @@ import skills_schema from './schemas/skills_schema';
 import users_schema from './schemas/users_schema';
 import curriculums_schema from './schemas/curriculums_schema';
 import languages_schema from './schemas/languages_schema';
+import educations_schema from './schemas/educations_schema';
 
 const database = new PostgresDB({
    dbName: process.env.POSTGRES_DB,
@@ -19,7 +20,8 @@ const database = new PostgresDB({
       companies_schema,
       experiences_schema,
       languages_schema,
-      curriculums_schema
+      curriculums_schema,
+      educations_schema
    ]
 });
 

--- a/src/database/models/educations_schema/Education/Education.ts
+++ b/src/database/models/educations_schema/Education/Education.ts
@@ -1,0 +1,25 @@
+import EducationSet from '../EducationSet/EducationSet';
+import { EducationSetup } from './Education.types';
+
+class Education extends EducationSet {
+   public institution_name: string;
+   public start_date: Date;
+   public end_date: Date;
+   public is_current: boolean;
+   public student_id: number;
+   public resume_id: number;
+
+   constructor(setup: EducationSetup) {
+      super(setup, 'educations_schema', 'educations');
+      const { institution_name, start_date, end_date, is_current, student_id, resume_id } = setup || {};
+
+      this.institution_name = institution_name;
+      this.start_date = start_date;
+      this.end_date = end_date;
+      this.is_current = is_current;
+      this.resume_id = resume_id;
+      this.student_id = student_id || this.user_id;
+   }
+}
+
+export default Education;

--- a/src/database/models/educations_schema/Education/Education.types.ts
+++ b/src/database/models/educations_schema/Education/Education.types.ts
@@ -1,9 +1,6 @@
 import { EducationSetSetup } from '../EducationSet/EducationSet.types';
 
 export interface EducationSetup extends EducationSetSetup {
-   id: number;
-   created_at: Date;
-   updated_at: Date;
    institution_name: string;
    start_date: Date;
    end_date: Date;

--- a/src/database/models/educations_schema/Education/Education.types.ts
+++ b/src/database/models/educations_schema/Education/Education.types.ts
@@ -1,0 +1,13 @@
+import { EducationSetSetup } from '../EducationSet/EducationSet.types';
+
+export interface EducationSetup extends EducationSetSetup {
+   id: number;
+   created_at: Date;
+   updated_at: Date;
+   institution_name: string;
+   start_date: Date;
+   end_date: Date;
+   is_current: boolean;
+   student_id: number;
+   resume_id: number;
+}

--- a/src/database/models/educations_schema/EducationSet/EducationSet.ts
+++ b/src/database/models/educations_schema/EducationSet/EducationSet.ts
@@ -1,0 +1,25 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { EducationSetSetup } from './EducationSet.types';
+
+class EducationSet extends TableRow {
+   public degree?: string;
+   public field_of_study?: string;
+   public grade?: string | null;
+   public description?: string | null;
+   public education_id: number;
+   public user_id: number;
+
+   constructor(setup: EducationSetSetup, schemaName: string = 'educations_schema', tableName: string = 'education_sets') {
+      super(schemaName, tableName, setup);
+      const { degree, field_of_study, grade, description, education_id, user_id } = setup || {};
+
+      this.degree = degree;
+      this.field_of_study = field_of_study;
+      this.grade = grade;
+      this.description = description;
+      this.education_id = education_id;
+      this.user_id = user_id;
+   }
+}
+
+export default EducationSet;

--- a/src/database/models/educations_schema/EducationSet/EducationSet.types.ts
+++ b/src/database/models/educations_schema/EducationSet/EducationSet.types.ts
@@ -1,0 +1,11 @@
+export interface EducationSetSetup {
+   id: number;
+   created_at: Date;
+   updated_at: Date;
+   degree?: string;
+   field_of_study?: string;
+   grade?: string | null;
+   description?: string | null;
+   education_id: number;
+   user_id: number;
+}

--- a/src/database/models/educations_schema/index.ts
+++ b/src/database/models/educations_schema/index.ts
@@ -1,0 +1,2 @@
+export { default as Education } from './Education/Education';
+export { default as EducationSet } from './EducationSet/EducationSet';

--- a/src/database/schemas/educations_schema.ts
+++ b/src/database/schemas/educations_schema.ts
@@ -1,0 +1,8 @@
+import Schema from '../../services/Database/models/Schema';
+import educations from '../../database/tables/educations_schema/educations';
+import education_sets from '../../database/tables/educations_schema/education_sets';
+
+export default new Schema({
+   name: 'educations_schema',
+   tables: [ educations, education_sets ]
+});

--- a/src/database/tables/educations_schema/education_sets.ts
+++ b/src/database/tables/educations_schema/education_sets.ts
@@ -1,0 +1,34 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'education_sets',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'degree', type: 'VARCHAR(255)' },
+      { name: 'field_of_study', type: 'VARCHAR(255)' },
+      { name: 'grade', type: 'VARCHAR(50)' },
+      { name: 'description', type: 'TEXT' },
+      {
+         name: 'education_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'educations_schema',
+            table: 'educations',
+            field: 'id'
+         }
+      },
+      {
+         name: 'user_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'users_schema',
+            table: 'admin_users',
+            field: 'id'
+         }
+      }
+   ]
+});

--- a/src/database/tables/educations_schema/educations.ts
+++ b/src/database/tables/educations_schema/educations.ts
@@ -1,0 +1,34 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'educations',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'institution_name', type: 'VARCHAR(255)', notNull: true },
+      { name: 'start_date', type: 'DATE', notNull: true },
+      { name: 'end_date', type: 'DATE', notNull: false },
+      { name: 'is_current', type: 'BOOLEAN', defaultValue: false },
+      {
+         name: 'student_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'users_schema',
+            table: 'admin_users',
+            field: 'id'
+         }
+      },
+      {
+         name: 'resume_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'curriculums_schema',
+            table: 'cvs',
+            field: 'id'
+         }
+      }
+   ]
+});


### PR DESCRIPTION
## [FRCV-120] Description
This pull request introduces a new `educations_schema` to the database, adding support for managing education records and their associated details. The changes include new schema and table definitions, model classes, and integration of the new schema into the database initialization. Below are the most important changes grouped by theme:

**Schema and Table Definitions:**

* Added a new `educations_schema` with two tables: `educations` (for education records) and `education_sets` (for detailed education attributes). (`src/database/schemas/educations_schema.ts`, `src/database/tables/educations_schema/educations.ts`, `src/database/tables/educations_schema/education_sets.ts`) [[1]](diffhunk://#diff-b951c6c83f52ca06bface2b915e9ae253e148ba8e768799a9f3efdbd40512af1R1-R8) [[2]](diffhunk://#diff-48072f5d7edb759aba253f7b769a97b14038f1db95159fbc44b6b9662eb202bdR1-R34) [[3]](diffhunk://#diff-7116ce140113adf2b88f2e552bc16bee3da4860882f3a201521c222f62be80a5R1-R34)

**Model Classes:**

* Introduced `Education` and `EducationSet` model classes, along with their type definitions, to represent and handle education data in the application. (`src/database/models/educations_schema/Education/Education.ts`, `src/database/models/educations_schema/Education/Education.types.ts`, `src/database/models/educations_schema/EducationSet/EducationSet.ts`, `src/database/models/educations_schema/EducationSet/EducationSet.types.ts`) [[1]](diffhunk://#diff-e0e0d8b4db5b658fdc0bb0f65ded481f83ea30a0982ea3e8cb2dc4412baf3daeR1-R25) [[2]](diffhunk://#diff-3fc0cec7959b4c1be205b21164d6d2212363ddf4b3489be69ef968380d358620R1-R13) [[3]](diffhunk://#diff-66c181b229eaefafa974edce49dff8fe1963259785dceee5ded9bb8bb538fe92R1-R25) [[4]](diffhunk://#diff-2d8e14e7dac9591a44fb6d4efa5d4f48992e0cc6526857d69cc27110ba1b4625R1-R11)
* Exported the new model classes for use elsewhere in the codebase. (`src/database/models/educations_schema/index.ts`)

**Database Integration:**

* Registered the new `educations_schema` in the main database initialization so that it is included when the application starts. (`src/database/index.ts`) [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R9) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352L22-R24)

[FRCV-120]: https://feliperamosdev.atlassian.net/browse/FRCV-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ