### PR TITLE
[FRCV-119] Education Features

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -49,9 +49,16 @@ import curriculumSetMaster from '../routes/curriculum/set-master.route';
 import curriculumDelete from '../routes/curriculum/delete.route';
 import curriculumPublicGet from '../routes/curriculum/public/cv_id.route';
 
+import educationCreate from '../routes/education/create.route';
+import educationGet from '../routes/education/education_id.route';
+import educationUpdate from '../routes/education/update.route';
+import educationUpdateSet from '../routes/education/update-set.route';
+import educationDelete from '../routes/education/delete.route';
+
 import userUpdate from '../routes/user/update.route';
 import userMasterCV from '../routes/user/master-cv.route';
 import userLanguages from '../routes/user/languages.route';
+import userEducations from '../routes/user/educations.route';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.replace(/ /g, '').split(',') : undefined;
@@ -128,9 +135,15 @@ global.service = new ServerAPI({
       curriculumSetMaster,
       curriculumDelete,
       curriculumPublicGet,
+      educationCreate,
+      educationGet,
+      educationUpdate,
+      educationUpdateSet,
+      educationDelete,
       userUpdate,
       userMasterCV,
-      userLanguages
+      userLanguages,
+      userEducations
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,6 +6,7 @@ import skills_schema from './schemas/skills_schema';
 import users_schema from './schemas/users_schema';
 import curriculums_schema from './schemas/curriculums_schema';
 import languages_schema from './schemas/languages_schema';
+import educations_schema from './schemas/educations_schema';
 
 const database = new PostgresDB({
    dbName: process.env.POSTGRES_DB,
@@ -19,7 +20,8 @@ const database = new PostgresDB({
       companies_schema,
       experiences_schema,
       languages_schema,
-      curriculums_schema
+      curriculums_schema,
+      educations_schema
    ]
 });
 

--- a/src/database/models/educations_schema/Education/Education.ts
+++ b/src/database/models/educations_schema/Education/Education.ts
@@ -1,0 +1,25 @@
+import EducationSet from '../EducationSet/EducationSet';
+import { EducationSetup } from './Education.types';
+
+class Education extends EducationSet {
+   public institution_name: string;
+   public start_date: Date;
+   public end_date: Date;
+   public is_current: boolean;
+   public student_id: number;
+   public resume_id: number;
+
+   constructor(setup: EducationSetup) {
+      super(setup, 'educations_schema', 'educations');
+      const { institution_name, start_date, end_date, is_current, student_id, resume_id } = setup || {};
+
+      this.institution_name = institution_name;
+      this.start_date = start_date;
+      this.end_date = end_date;
+      this.is_current = is_current;
+      this.resume_id = resume_id;
+      this.student_id = student_id || this.user_id;
+   }
+}
+
+export default Education;

--- a/src/database/models/educations_schema/Education/Education.ts
+++ b/src/database/models/educations_schema/Education/Education.ts
@@ -1,5 +1,8 @@
+import database from '../../../../database';
 import EducationSet from '../EducationSet/EducationSet';
 import { EducationSetup } from './Education.types';
+import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
+import { defaultLocale, locales } from '../../../../app.config';
 
 class Education extends EducationSet {
    public institution_name: string;
@@ -7,18 +10,192 @@ class Education extends EducationSet {
    public end_date: Date;
    public is_current: boolean;
    public student_id: number;
-   public resume_id: number;
+
+   static populateFields = [
+      'educations.id',
+      'institution_name',
+      'start_date',
+      'end_date',
+      'is_current',
+      'student_id'
+   ];
 
    constructor(setup: EducationSetup) {
       super(setup, 'educations_schema', 'educations');
-      const { institution_name, start_date, end_date, is_current, student_id, resume_id } = setup || {};
+      const { institution_name, start_date, end_date, is_current, student_id } = setup || {};
 
       this.institution_name = institution_name;
       this.start_date = start_date;
       this.end_date = end_date;
-      this.is_current = is_current;
-      this.resume_id = resume_id;
+      this.is_current = Boolean(is_current);
       this.student_id = student_id || this.user_id;
+   }
+
+   toObject() {
+      return {
+         id: this.id,
+         created_at: this.created_at,
+         updated_at: this.updated_at,
+         institution_name: this.institution_name,
+         start_date: this.start_date,
+         end_date: this.end_date,
+         is_current: this.is_current,
+         student_id: this.student_id
+      }
+   }
+
+   toCreate() {
+      const result = this.toObject();
+
+      delete result.id;
+      delete result.created_at;
+      delete result.updated_at;
+
+      return result;
+   }
+
+   async save() {
+      const toAbort = [];
+
+      try {
+         const { data = [], error } = await database.insert(this.schemaName, this.tableName).data(this.toCreate()).returning().exec();
+         const [ created ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to save education', 'ERR_SAVE_FAILED', 'Database Error');
+         }
+
+         if (!created) {
+            throw new ErrorDatabase('Failed to save education', 'ERR_SAVE_FAILED', 'Database Error');
+         }
+
+         toAbort.push(database.delete(this.schemaName, this.tableName).where({ id: created.id }));
+
+         const defaultSet = await EducationSet.create({
+            education_id: created.id,
+            language_set: defaultLocale,
+            user_id: this.user_id,
+            degree: this.degree,
+            field_of_study: this.field_of_study,
+            grade: this.grade,
+            description: this.description
+         });
+
+         if (!defaultSet) {
+            throw new ErrorDatabase('Failed to create default education set', 'ERR_CREATE_SET_FAILED');
+         }
+
+         toAbort.push(database.delete(this.schemaName, 'education_sets').where({ id: defaultSet.id }));
+         for (const locale of locales) {
+            if (locale === defaultLocale) {
+               continue;
+            }
+
+            const createdSet = await EducationSet.create({
+               education_id: created.id,
+               language_set: locale,
+               user_id: this.user_id
+            });
+
+            if (!createdSet) {
+               throw new ErrorDatabase(`Failed to create education set for locale ${locale}`, 'ERR_CREATE_SET_FAILED');
+            }
+
+            toAbort.push(database.delete(this.schemaName, 'education_sets').where({ id: createdSet.id }));
+         }
+
+         return new Education({ ...created, ...defaultSet.toObjectSet() });
+      } catch (error: any) {
+         toAbort.forEach(item => item.exec().catch((err) => console.error(err)));
+         throw new ErrorDatabase(error.message, error.code || 'ERR_SAVE_FAILED', 'Database Error');
+      }
+   }
+
+   static async findById(id: number, language_set: string = defaultLocale): Promise<Education | null> {
+      try {
+         const query = database.select('educations_schema', 'education_sets');
+
+         query.where({ education_id: id, language_set });
+         query.populate('education_id', this.populateFields);
+
+         const { data = [], error } = await query.exec();
+         const [ education ] = data;
+   
+         if (error) {
+            throw new ErrorDatabase('Failed to find education', 'ERR_FIND_FAILED');
+         }
+   
+         if (!education) {
+            return null;
+         }
+   
+         return new Education(education);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_FIND_FAILED');
+      }
+   }
+
+   static async findByUserId(user_id: number, language_set: string = defaultLocale): Promise<Education[]> {
+      try {
+         const query = database.select('educations_schema', 'education_sets');
+
+         query.where({ user_id, language_set });
+         query.populate('education_id', this.populateFields);
+
+         const { data = [], error } = await query.exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to find educations', 'ERR_FIND_FAILED');
+         }
+
+         return data.map(item => new Education(item));
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_FIND_FAILED');
+      }
+   }
+
+   static async update(education_id: number, updates: Partial<EducationSetup>): Promise<Education | null> {
+      try {
+         const { data = [], error } = await database.update('educations_schema', 'educations').set(updates).where({ id: education_id }).returning().exec();
+         const [ updated ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to update education', 'ERR_UPDATE_FAILED');
+         }
+
+         if (!updated) {
+            return null;
+         }
+
+         return new Education(updated);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_UPDATE_FAILED');
+      }
+   }
+
+   static async delete(education_id: number): Promise<boolean> {
+      try {
+         const { error } = await database.delete('educations_schema', 'education_sets').where({ education_id }).returning().exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to delete education', 'ERR_DELETE_FAILED', 'Database Error');
+         }
+
+         const { data = [], error: mainError } = await database.delete('educations_schema', 'educations').where({ id: education_id }).returning().exec();
+         const [ deleted ] = data;
+
+         if (mainError) {
+            throw new ErrorDatabase('Failed to delete education', 'ERR_DELETE_FAILED', 'Database Error');
+         }
+
+         if (!deleted) {
+            return false;
+         }
+
+         return true;
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_DELETE_FAILED');
+      }
    }
 }
 

--- a/src/database/models/educations_schema/Education/Education.types.ts
+++ b/src/database/models/educations_schema/Education/Education.types.ts
@@ -6,5 +6,4 @@ export interface EducationSetup extends EducationSetSetup {
    end_date: Date;
    is_current: boolean;
    student_id: number;
-   resume_id: number;
 }

--- a/src/database/models/educations_schema/Education/Education.types.ts
+++ b/src/database/models/educations_schema/Education/Education.types.ts
@@ -1,0 +1,10 @@
+import { EducationSetSetup } from '../EducationSet/EducationSet.types';
+
+export interface EducationSetup extends EducationSetSetup {
+   institution_name: string;
+   start_date: Date;
+   end_date: Date;
+   is_current: boolean;
+   student_id: number;
+   resume_id: number;
+}

--- a/src/database/models/educations_schema/EducationSet/EducationSet.ts
+++ b/src/database/models/educations_schema/EducationSet/EducationSet.ts
@@ -1,17 +1,20 @@
+import ErrorDatabase from '../../../../services/Database/ErrorDatabase';
 import TableRow from '../../../../services/Database/models/TableRow';
-import { EducationSetSetup } from './EducationSet.types';
+import { EducationSetCreate, EducationSetSetup } from './EducationSet.types';
+import database from '../../../../database';
 
 class EducationSet extends TableRow {
    public degree?: string;
    public field_of_study?: string;
-   public grade?: string | null;
-   public description?: string | null;
+   public grade?: string;
+   public description?: string;
    public education_id: number;
+   public language_set: string;
    public user_id: number;
 
    constructor(setup: EducationSetSetup, schemaName: string = 'educations_schema', tableName: string = 'education_sets') {
       super(schemaName, tableName, setup);
-      const { degree, field_of_study, grade, description, education_id, user_id } = setup || {};
+      const { degree, field_of_study, grade, description, education_id, user_id, language_set } = setup || {};
 
       this.degree = degree;
       this.field_of_study = field_of_study;
@@ -19,6 +22,60 @@ class EducationSet extends TableRow {
       this.description = description;
       this.education_id = education_id;
       this.user_id = user_id;
+      this.language_set = language_set;
+   }
+
+   toObjectSet() {
+      return {
+         id: this.id,
+         created_at: this.created_at,
+         updated_at: this.updated_at,
+         degree: this.degree,
+         field_of_study: this.field_of_study,
+         grade: this.grade,
+         description: this.description,
+         education_id: this.education_id,
+         user_id: this.user_id,
+         language_set: this.language_set
+      }
+   }
+
+   static async create(values: EducationSetCreate): Promise<EducationSet> {
+      try {
+         const { data = [], error } = await database.insert('educations_schema', 'education_sets').data(values).returning().exec();
+         const [ created ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to create education set', 'ERR_CREATE_FAILED', 'Database Error');
+         }
+
+         if (!created) {
+            throw new ErrorDatabase('Failed to create education set', 'ERR_CREATE_FAILED', 'Database Error');
+         }
+
+         return new EducationSet(created);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_CREATE_FAILED');
+      }
+   }
+
+   static async updateSet(id: number, updates: Partial<EducationSetSetup>): Promise<EducationSet | null> {
+      try {
+         const { data = [], error } = await database.update('educations_schema', 'education_sets').set(updates).where({ id }).returning().exec();
+         const [ updated ] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to update education set', 'ERR_UPDATE_FAILED', 'Database Error');
+         }
+
+         if (!updated) {
+            return null;
+         }
+
+         return new EducationSet(updated);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_UPDATE_FAILED');
+      }
    }
 }
 

--- a/src/database/models/educations_schema/EducationSet/EducationSet.ts
+++ b/src/database/models/educations_schema/EducationSet/EducationSet.ts
@@ -1,0 +1,25 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { EducationSetSetup } from './EducationSet.types';
+
+class EducationSet extends TableRow {
+   public degree?: string;
+   public field_of_study?: string;
+   public grade?: string | null;
+   public description?: string | null;
+   public education_id: number;
+   public user_id: number;
+
+   constructor(setup: EducationSetSetup, schemaName: string = 'educations_schema', tableName: string = 'education_sets') {
+      super(schemaName, tableName, setup);
+      const { degree, field_of_study, grade, description, education_id, user_id } = setup || {};
+
+      this.degree = degree;
+      this.field_of_study = field_of_study;
+      this.grade = grade;
+      this.description = description;
+      this.education_id = education_id;
+      this.user_id = user_id;
+   }
+}
+
+export default EducationSet;

--- a/src/database/models/educations_schema/EducationSet/EducationSet.types.ts
+++ b/src/database/models/educations_schema/EducationSet/EducationSet.types.ts
@@ -4,8 +4,19 @@ export interface EducationSetSetup {
    updated_at: Date;
    degree?: string;
    field_of_study?: string;
-   grade?: string | null;
-   description?: string | null;
+   grade?: string;
+   description?: string;
+   education_id: number;
+   language_set: string;
+   user_id: number;
+}
+
+export interface EducationSetCreate {
+   degree?: string;
+   field_of_study?: string;
+   grade?: string;
+   description?: string;
    education_id: number;
    user_id: number;
+   language_set: string;
 }

--- a/src/database/models/educations_schema/EducationSet/EducationSet.types.ts
+++ b/src/database/models/educations_schema/EducationSet/EducationSet.types.ts
@@ -1,0 +1,11 @@
+export interface EducationSetSetup {
+   id: number;
+   created_at: Date;
+   updated_at: Date;
+   degree?: string;
+   field_of_study?: string;
+   grade?: string | null;
+   description?: string | null;
+   education_id: number;
+   user_id: number;
+}

--- a/src/database/models/educations_schema/index.ts
+++ b/src/database/models/educations_schema/index.ts
@@ -1,0 +1,2 @@
+export { default as Education } from './Education/Education';
+export { default as EducationSet } from './EducationSet/EducationSet';

--- a/src/database/schemas/educations_schema.ts
+++ b/src/database/schemas/educations_schema.ts
@@ -1,0 +1,8 @@
+import Schema from '../../services/Database/models/Schema';
+import educations from '../../database/tables/educations_schema/educations';
+import education_sets from '../../database/tables/educations_schema/education_sets';
+
+export default new Schema({
+   name: 'educations_schema',
+   tables: [ educations, education_sets ]
+});

--- a/src/database/tables/educations_schema/education_sets.ts
+++ b/src/database/tables/educations_schema/education_sets.ts
@@ -1,0 +1,34 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'education_sets',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'degree', type: 'VARCHAR(255)' },
+      { name: 'field_of_study', type: 'VARCHAR(255)' },
+      { name: 'grade', type: 'VARCHAR(50)' },
+      { name: 'description', type: 'TEXT' },
+      {
+         name: 'education_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'educations_schema',
+            table: 'educations',
+            field: 'id'
+         }
+      },
+      {
+         name: 'user_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'users_schema',
+            table: 'admin_users',
+            field: 'id'
+         }
+      }
+   ]
+});

--- a/src/database/tables/educations_schema/education_sets.ts
+++ b/src/database/tables/educations_schema/education_sets.ts
@@ -1,3 +1,4 @@
+import { defaultLocale } from '../../../app.config';
 import Table from '../../../services/Database/models/Table';
 
 export default new Table({
@@ -10,6 +11,7 @@ export default new Table({
       { name: 'field_of_study', type: 'VARCHAR(255)' },
       { name: 'grade', type: 'VARCHAR(50)' },
       { name: 'description', type: 'TEXT' },
+      { name: 'language_set', type: 'VARCHAR(2)', defaultValue: defaultLocale },
       {
          name: 'education_id',
          type: 'INTEGER',

--- a/src/database/tables/educations_schema/educations.ts
+++ b/src/database/tables/educations_schema/educations.ts
@@ -19,16 +19,6 @@ export default new Table({
             table: 'admin_users',
             field: 'id'
          }
-      },
-      {
-         name: 'resume_id',
-         type: 'INTEGER',
-         notNull: true,
-         relatedField: {
-            schema: 'curriculums_schema',
-            table: 'cvs',
-            field: 'id'
-         }
       }
    ]
 });

--- a/src/database/tables/educations_schema/educations.ts
+++ b/src/database/tables/educations_schema/educations.ts
@@ -1,0 +1,34 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'educations',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'institution_name', type: 'VARCHAR(255)', notNull: true },
+      { name: 'start_date', type: 'DATE', notNull: true },
+      { name: 'end_date', type: 'DATE', notNull: false },
+      { name: 'is_current', type: 'BOOLEAN', defaultValue: false },
+      {
+         name: 'student_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'users_schema',
+            table: 'admin_users',
+            field: 'id'
+         }
+      },
+      {
+         name: 'resume_id',
+         type: 'INTEGER',
+         notNull: true,
+         relatedField: {
+            schema: 'curriculums_schema',
+            table: 'cvs',
+            field: 'id'
+         }
+      }
+   ]
+});

--- a/src/routes/education/create.route.ts
+++ b/src/routes/education/create.route.ts
@@ -1,0 +1,27 @@
+import { Education } from '../../database/models/educations_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'POST',
+   routePath: '/education/create',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const userId = req.session.user?.id;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User not found', 401, 'ERR_UNAUTHORIZED').send(res);
+         return;
+      }
+
+      try {
+         const education = new Education({ ...req.body, user_id: userId });
+         const created = await education.save();
+
+         res.status(201).send(created);
+      } catch (error) {
+         new ErrorResponseServerAPI('Failed to create education', 500, 'ERR_CREATE_FAILED').send(res);
+      }
+   }
+});

--- a/src/routes/education/delete.route.ts
+++ b/src/routes/education/delete.route.ts
@@ -1,0 +1,37 @@
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Education } from '../../database/models/educations_schema';
+import { Route } from '../../services';
+
+export default new Route({
+   method: 'DELETE',
+   routePath: '/education/delete',
+   useAuth: true,
+   allowedRoles: ['master', 'admin'],
+   controller: async (req, res) => {
+      const { education_id } = req.body;
+      const educationId = Number(education_id);
+
+      if (!education_id) {
+         new ErrorResponseServerAPI('Education ID is required', 400, 'ERR_INVALID_INPUT').send(res);
+         return;
+      }
+
+      if (isNaN(educationId) || educationId <= 0) {
+         new ErrorResponseServerAPI('Invalid Education ID', 400, 'ERR_INVALID_INPUT').send(res);
+         return;
+      }
+
+      try {
+         const deleted = await Education.delete(educationId);
+
+         if (!deleted) {
+            new ErrorResponseServerAPI('Education not found', 404, 'ERR_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send({ message: 'Education deleted successfully' });
+      } catch (error: any) {
+         new ErrorResponseServerAPI('Failed to delete education record', 500, 'ERR_DELETE_FAILED').send(res);
+      }
+   }
+});

--- a/src/routes/education/education_id.route.ts
+++ b/src/routes/education/education_id.route.ts
@@ -1,0 +1,35 @@
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Route } from '../../services';
+import { Education } from '../../database/models/educations_schema';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/education/:education_id',
+   controller: async (req, res) => {
+      const { education_id } = req.params;
+      const { language_set } = req.query;
+      const educationId = Number(education_id);
+
+      if (!education_id) {
+         new ErrorResponseServerAPI('Education ID is required', 400, 'EDUCATION_ID_REQUIRED').send(res);
+         return;
+      }
+
+      if (isNaN(educationId)) {
+         new ErrorResponseServerAPI('Education ID must be a number', 400, 'EDUCATION_ID_MUST_BE_NUMBER').send(res);
+         return;
+      }
+
+      try {
+         const educationRecord = await Education.findById(educationId, language_set as string | undefined);
+         if (!educationRecord) {
+            new ErrorResponseServerAPI('Education record not found', 404, 'EDUCATION_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(educationRecord);
+      } catch (error) {
+         new ErrorResponseServerAPI('Server error', 500, 'SERVER_ERROR').send(res);
+      }
+   }
+});

--- a/src/routes/education/update-set.route.ts
+++ b/src/routes/education/update-set.route.ts
@@ -1,0 +1,38 @@
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Route } from '../../services';
+import { EducationSet } from '../../database/models/educations_schema';
+
+export default new Route({
+   method: 'PATCH',
+   routePath: '/education/update-set',
+   useAuth: true,
+   allowedRoles: ['master', 'admin'],
+   controller: async (req, res) => {
+      const { set_id, updates } = req.body;
+      const setId = Number(set_id);
+
+      if (!set_id || !updates) {
+         new ErrorResponseServerAPI('Education Set ID and updates are required', 400, 'EDUCATION_SET_ID_AND_UPDATES_REQUIRED').send(res);
+         return;
+      }
+
+      if (isNaN(setId) || setId <= 0) {
+         new ErrorResponseServerAPI('Invalid Education Set ID', 400, 'INVALID_EDUCATION_SET_ID').send(res);
+         return;
+      }
+
+      try {
+         const updated = await EducationSet.updateSet(setId, updates);
+
+         if (!updated) {
+            new ErrorResponseServerAPI('Failed to update education set record', 404, 'EDUCATION_SET_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(updated);
+      } catch (error: any) {
+         new ErrorResponseServerAPI('Failed to update education set record', 500, 'EDUCATION_SET_UPDATE_FAILED').send(res);
+      }
+   }
+});
+

--- a/src/routes/education/update.route.ts
+++ b/src/routes/education/update.route.ts
@@ -1,0 +1,37 @@
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Route } from '../../services';
+import { Education } from '../../database/models/educations_schema';
+
+export default new Route({
+   method: 'PATCH',
+   routePath: '/education/update',
+   useAuth: true,
+   allowedRoles: ['master', 'admin'],
+   controller: async (req, res) => {
+      const { education_id, updates } = req.body;
+      const educationId = Number(education_id);
+
+      if (!education_id || !updates) {
+         new ErrorResponseServerAPI('Education ID and updates are required', 400, 'EDUCATION_ID_AND_UPDATES_REQUIRED').send(res);
+         return;
+      }
+
+      if (isNaN(educationId) || educationId <= 0) {
+         new ErrorResponseServerAPI('Invalid Education ID', 400, 'INVALID_EDUCATION_ID').send(res);
+         return;
+      }
+
+      try {
+         const updated = await Education.update(educationId, updates);
+
+         if (!updated) {
+            new ErrorResponseServerAPI('Failed to update education record', 404, 'EDUCATION_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(200).send(updated);
+      } catch (error: any) {
+         new ErrorResponseServerAPI('Failed to update education record', 500, 'EDUCATION_UPDATE_FAILED').send(res);
+      }
+   }
+});

--- a/src/routes/user/educations.route.ts
+++ b/src/routes/user/educations.route.ts
@@ -1,0 +1,26 @@
+import { Education } from '../../database/models/educations_schema';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+
+export default new Route({
+   method: 'GET',
+   routePath: '/user/educations',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   controller: async (req, res) => {
+      const { language_set } = req.query;
+      const userId = req.session.user?.id;
+
+      if (!userId) {
+         new ErrorResponseServerAPI('User ID not found in session', 401, 'ERR_UNAUTHORIZED').send(res);
+         return;
+      }
+
+      try {
+         const educations = await Education.findByUserId(userId, language_set as string);
+         res.status(200).send(educations);
+      } catch (error) {
+         new ErrorResponseServerAPI('Failed to fetch user educations', 500, 'ERR_FETCH_FAILED').send(res);
+      }
+   }
+});


### PR DESCRIPTION
## [FRCV-119] Description
This pull request introduces a comprehensive "Education" feature to the codebase, enabling CRUD operations for education records and their localized details. It adds new database schemas and models, integrates them into the API server, and provides routes for creating, updating, retrieving, and deleting education data associated with users.

**Education feature implementation:**

* Added `educations_schema` to the database, including new tables `educations` and `education_sets` for storing education records and their localized details. [[1]](diffhunk://#diff-b951c6c83f52ca06bface2b915e9ae253e148ba8e768799a9f3efdbd40512af1R1-R8) [[2]](diffhunk://#diff-7116ce140113adf2b88f2e552bc16bee3da4860882f3a201521c222f62be80a5R1-R36) [[3]](diffhunk://#diff-48072f5d7edb759aba253f7b769a97b14038f1db95159fbc44b6b9662eb202bdR1-R24)
* Implemented `Education` and `EducationSet` models with methods for creating, updating, retrieving, and deleting education records, including locale-aware sets and error handling. [[1]](diffhunk://#diff-e0e0d8b4db5b658fdc0bb0f65ded481f83ea30a0982ea3e8cb2dc4412baf3daeR1-R202) [[2]](diffhunk://#diff-66c181b229eaefafa974edce49dff8fe1963259785dceee5ded9bb8bb538fe92R1-R82) [[3]](diffhunk://#diff-3fc0cec7959b4c1be205b21164d6d2212363ddf4b3489be69ef968380d358620R1-R9) [[4]](diffhunk://#diff-2d8e14e7dac9591a44fb6d4efa5d4f48992e0cc6526857d69cc27110ba1b4625R1-R22) [[5]](diffhunk://#diff-f4ef6053f14c30421e81b2236c983d2b15650ac17032121ffc1b6340ce8e1a20R1-R2)

**API server integration:**

* Registered new education-related routes in the API server, including endpoints for creating, retrieving, updating, and deleting education records and sets. [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR52-R61) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR138-R146)

**Education API endpoints:**

* Added routes for:
  - Creating an education record (`/education/create`)
  - Retrieving an education record by ID (`/education/:education_id`)
  - Updating an education set (`/education/update-set`)
  - Deleting an education record (`/education/delete`)

**Database integration:**

* Integrated the new `educations_schema` with the main database configuration to ensure migrations and connections are established. [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R9) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352L22-R24)

### Sub-tasks
* [FRCV-120] Educations Schema, Tables and Models (#117)
Introduced a new 'educations_schema' to the database, including models (Education, EducationSet), their type definitions, and table definitions for 'educations' and 'education_sets'. Updated the database index to register the new schema. This enables structured storage and management of education-related data linked to users and resumes.

* [FRCV-121] Education Routes (#118)
Introduces full CRUD API routes for education records, including create, read (by ID and by user), update, and delete endpoints. Refactors Education and EducationSet models to support new operations, removes resume_id from education schema, adds language_set to education_sets, and updates related types and table definitions.

[FRCV-119]: https://feliperamosdev.atlassian.net/browse/FRCV-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FRCV-120]: https://feliperamosdev.atlassian.net/browse/FRCV-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ