### PR TITLE
[FRCV-122] Educations Full Load

### DIFF
--- a/src/routes/education/education_id.route.ts
+++ b/src/routes/education/education_id.route.ts
@@ -7,7 +7,6 @@ export default new Route({
    routePath: '/education/:education_id',
    controller: async (req, res) => {
       const { education_id } = req.params;
-      const { language_set } = req.query;
       const educationId = Number(education_id);
 
       if (!education_id) {
@@ -21,7 +20,7 @@ export default new Route({
       }
 
       try {
-         const educationRecord = await Education.findById(educationId, language_set as string | undefined);
+         const educationRecord = await Education.getFullById(educationId);
          if (!educationRecord) {
             new ErrorResponseServerAPI('Education record not found', 404, 'EDUCATION_NOT_FOUND').send(res);
             return;


### PR DESCRIPTION
## [FRCV-122] Description
This pull request enhances how education records are retrieved and represented, especially regarding associated language sets. The main focus is on adding support for loading related `EducationSet` objects for an `Education` record and updating the route to use this new functionality.

**Model enhancements:**

* Added a `languageSets` property to the `Education` class to hold associated `EducationSet` objects and initialized it in the constructor. [[1]](diffhunk://#diff-e0e0d8b4db5b658fdc0bb0f65ded481f83ea30a0982ea3e8cb2dc4412baf3daeR13) [[2]](diffhunk://#diff-e0e0d8b4db5b658fdc0bb0f65ded481f83ea30a0982ea3e8cb2dc4412baf3daeR32)
* Implemented the `loadLanguageSets` method in the `Education` class to asynchronously load and populate the `languageSets` property from the database.
* Added a static `getFullById` method to the `Education` class that retrieves an `Education` record by ID and loads its associated language sets.

**Route changes:**

* Updated the `/education/:education_id` route to use the new `getFullById` method instead of the previous `findById`, ensuring that the returned education record includes its language sets.
* Removed the unused `language_set` query parameter from the route controller, simplifying the API.