### PR TITLE
[FRCV-123] Link Education and Languages to the CV

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -177,8 +177,7 @@ export default class CV extends CVSet {
       }
 
       try {
-         const [languageIndex] = this.cv_languages;
-         if (typeof languageIndex === 'number') {
+         if (this.cv_languages.every(item => typeof item === 'number')) {
             this.cv_languages = await Language.getManyById(this.cv_languages as number[]);
          }
 
@@ -195,8 +194,7 @@ export default class CV extends CVSet {
       }
 
       try {
-         const [educationIndex] = this.cv_educations;
-         if (typeof educationIndex === 'number') {
+         if (this.cv_educations.every(e => typeof e === 'number')) {
             this.cv_educations = await Education.getManyById(this.cv_educations as number[], this.language_set);
          }
 

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -1,7 +1,9 @@
-import { ExperienceSetup } from "../../experiences_schema/Experience/Experience.types";
-import { SkillSetup } from "../../skills_schema/Skill/Skill.types";
-import CVSet from "../CVSet/CVSet";
-import { CVSetSetup } from "../CVSet/CVSet.types";
+import { EducationSetup } from '../../educations_schema/Education/Education.types';
+import { ExperienceSetup } from '../../experiences_schema/Experience/Experience.types';
+import { LanguageSetup } from '../../languages_schema/Language/Language.types';
+import { SkillSetup } from '../../skills_schema/Skill/Skill.types';
+import CVSet from '../CVSet/CVSet';
+import { CVSetSetup } from '../CVSet/CVSet.types';
 
 export interface CVSetup extends CVSetSetup {
    title: string;
@@ -10,6 +12,8 @@ export interface CVSetup extends CVSetSetup {
    notes?: string;
    cv_experiences?: (ExperienceSetup | number)[];
    cv_skills?: (SkillSetup | number)[];
+   cv_educations?: (EducationSetup | number)[];
+   cv_languages?: (LanguageSetup | number)[];
    cv_owner?: number; 
    languageSets?: CVSet[];
    cv_owner_id?: number;

--- a/src/database/models/educations_schema/Education/Education.ts
+++ b/src/database/models/educations_schema/Education/Education.ts
@@ -162,6 +162,24 @@ class Education extends EducationSet {
       }
    }
 
+   static async getManyById(education_ids: number[], language_set: string = defaultLocale): Promise<Education[]> {
+      try {
+         const query = database.select('educations_schema', 'education_sets');
+         query.where(education_ids.map(id => ({ education_id: id, language_set })));
+         query.populate('education_id', this.populateFields);
+
+         const { data = [], error } = await query.exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to find educations', 'ERR_FIND_FAILED');
+         }
+
+         return data.map(item => new Education(item)).filter(education => education.language_set === language_set);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'ERR_FIND_FAILED');
+      }
+   }
+
    static async getFullById(id: number): Promise<Education | null> {
       try {
          const query = database.select('educations_schema', 'educations').where({ id });

--- a/src/database/models/languages_schema/Language/Language.ts
+++ b/src/database/models/languages_schema/Language/Language.ts
@@ -50,8 +50,9 @@ class Language extends TableRow {
       const speakingScore = Language.levels.indexOf(this.speaking_level) + 1;
 
       const levelScore = (readingScore + listeningScore + writingScore + speakingScore) / 4;
+      const idx = Math.max(0, Math.min(Language.levels.length - 1, Math.floor(levelScore) - 1));
 
-      return Language.levels[Math.floor(levelScore) - 1];
+      return Language.levels[idx];
    }
 
    toObject() {

--- a/src/database/models/languages_schema/Language/Language.ts
+++ b/src/database/models/languages_schema/Language/Language.ts
@@ -17,6 +17,14 @@ class Language extends TableRow {
    public speaking_level: LanguageLevel;
    public language_user_id: number;
 
+   static levels = [
+      'beginner',
+      'intermediate',
+      'advanced',
+      'proficient',
+      'native'
+   ];
+
    constructor (setup: LanguageSetup) {
       super('languages_schema', 'languages', setup);
       const { default_name, local_name, locale_code, reading_level, listening_level, writing_level, speaking_level, language_user_id } = setup || {};
@@ -35,6 +43,17 @@ class Language extends TableRow {
       this.language_user_id = language_user_id;
    }
 
+   public get level() {
+      const readingScore = Language.levels.indexOf(this.reading_level) + 1;
+      const listeningScore = Language.levels.indexOf(this.listening_level) + 1;
+      const writingScore = Language.levels.indexOf(this.writing_level) + 1;
+      const speakingScore = Language.levels.indexOf(this.speaking_level) + 1;
+
+      const levelScore = (readingScore + listeningScore + writingScore + speakingScore) / 4;
+
+      return Language.levels[Math.floor(levelScore) - 1];
+   }
+
    toObject() {
       return {
          id: this.id,
@@ -43,6 +62,7 @@ class Language extends TableRow {
          default_name: this.default_name,
          local_name: this.local_name,
          locale_code: this.locale_code,
+         level: this.level,
          reading_level: this.reading_level,
          listening_level: this.listening_level,
          writing_level: this.writing_level,
@@ -94,6 +114,21 @@ class Language extends TableRow {
          }
 
          return new Language(found);
+      } catch (error: any) {
+         throw new ErrorDatabase(error.message, error.code || 'LANGUAGE_FIND_FAILED');
+      }
+   }
+
+   static async getManyById(language_ids: number[]): Promise<Language[]> {
+      try {
+         const wheres = language_ids.map(id => ({ id }));
+         const { data = [], error } = await database.select('languages_schema', 'languages').where(wheres).exec();
+
+         if (error) {
+            throw new ErrorDatabase('Failed to find Languages', 'LANGUAGE_FIND_FAILED');
+         }
+
+         return data.map(item => new Language(item));
       } catch (error: any) {
          throw new ErrorDatabase(error.message, error.code || 'LANGUAGE_FIND_FAILED');
       }

--- a/src/database/tables/curriculums_schema/cvs.ts
+++ b/src/database/tables/curriculums_schema/cvs.ts
@@ -15,6 +15,8 @@ export default new Table({
       { name: 'notes', type: 'TEXT' },
       { name: 'cv_experiences', type: 'INTEGER[]' },
       { name: 'cv_skills', type: 'INTEGER[]' },
+      { name: 'cv_languages', type: 'INTEGER[]' },
+      { name: 'cv_educations', type: 'INTEGER[]' },
       { name: 'cv_owner_id', type: 'INTEGER' },
    ],
    events: {

--- a/src/routes/user/languages.route.ts
+++ b/src/routes/user/languages.route.ts
@@ -23,7 +23,7 @@ export default new Route({
             return;
          }
 
-         res.status(200).send(languages);
+         res.status(200).send(languages.map(lang => lang.toObject()));
       } catch (error: any) {
          new ErrorResponseServerAPI(error.message, 500, error.code || 'Internal Server Error').send(res);
       }


### PR DESCRIPTION
## [FRCV-123] Description
This pull request extends the CV (curriculum vitae) model to support associated educations and languages, alongside existing experiences and skills. It introduces new fields, database schema updates, population methods, and data fetching utilities for `Education` and `Language` entities. Additionally, it improves how language proficiency levels are calculated and represented.

**CV Model Enhancements:**

* Added `cv_educations` and `cv_languages` fields to the `CV` class, constructor, and serialization logic, enabling CVs to reference education and language records. [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR21-R22) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cL29-R35) [[3]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR50-R51) [[4]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR81-R100) [[5]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR111-R112) [[6]](diffhunk://#diff-f0f2b74971f6bb1e5e21a3e12e764353b93cccb509a9b0ccbebe31747ee3f1f3R15-R16) [[7]](diffhunk://#diff-4bf6ea42e79ed11ca3988891b27ef7db53eaa424a1660e56d1ea524e5fdcb6e3R18-R19)
* Updated the CV population logic to include new `populateLanguages` and `populateEducations` methods, ensuring related language and education data are fetched and hydrated when loading a CV. [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR173-R208) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR296-R297) [[3]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR349-R350) [[4]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR380-R381)

**Education and Language Model Improvements:**

* Implemented `getManyById` static methods for both `Education` and `Language`, allowing batch retrieval of records by IDs. [[1]](diffhunk://#diff-e0e0d8b4db5b658fdc0bb0f65ded481f83ea30a0982ea3e8cb2dc4412baf3daeR165-R182) [[2]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R122-R136)
* Updated the `Education` and `Language` model imports/types in the CV model and types definitions. [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR11-R12) [[2]](diffhunk://#diff-f0f2b74971f6bb1e5e21a3e12e764353b93cccb509a9b0ccbebe31747ee3f1f3L1-R6)

**Language Proficiency Calculation:**

* Added a computed `level` property to the `Language` class that averages the four skill levels (reading, listening, writing, speaking) and exposes this in the serialized output. [[1]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R20-R27) [[2]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R46-R56) [[3]](diffhunk://#diff-2fa686f6a7f89926afce79966e32d8549a2d901e4614e9bbfbd4391a4e54a3f2R65)

**API Response Consistency:**

* Updated the user languages route to return language objects via their `toObject()` method, ensuring consistent API responses.

[FRCV-123]: https://feliperamosdev.atlassian.net/browse/FRCV-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ