### PR TITLE
[FRCV-128] Generate CV Summary Status Feedback

### DIFF
--- a/src/containers/namespaces/custom-cv/events/generate-summary.ts
+++ b/src/containers/namespaces/custom-cv/events/generate-summary.ts
@@ -35,9 +35,12 @@ const generateSummaryEvent: NamespaceEvent = {
             });
          },
          onJoin: (room, client) => {
+            this.sendToRoom(room.id, 'custom-cv:status', 'fetching-url');
+
             socketServer.sendTo('/virtual-browser/linkedin/job-description', { jobURL }, ({ error, message, jobDescription }) => {
                if (error) {
                   console.error('Job Description Error:', { error, message });
+                  this.sendToRoom(room.id, 'custom-cv:status', 'error');
 
                   return callback({
                      error: new ErrorSocketServer(
@@ -47,10 +50,11 @@ const generateSummaryEvent: NamespaceEvent = {
                   });
                }
 
-               console.log('Job Description Success:', { jobDescription });
+               this.sendToRoom(room.id, 'custom-cv:status', 'generating-summary');
                socketServer.sendTo('/ai/generate-cv-summary', { jobDescription }, ({ error: aiError, message: aiMessage, summary }) => {
                   if (aiError) {
                      console.error('AI Error:', { aiError, aiMessage });
+                     this.sendToRoom(room.id, 'custom-cv:status', 'error');
 
                      return callback({
                         error: new ErrorSocketServer(
@@ -60,7 +64,7 @@ const generateSummaryEvent: NamespaceEvent = {
                      });
                   }
 
-                  console.log('AI Success:', { summary });
+                  this.sendToRoom(room.id, 'custom-cv:status', 'success');
                   callback({ summary });
                });
             });

--- a/src/containers/routes/virtual-browser/linkedin/job-description.route.ts
+++ b/src/containers/routes/virtual-browser/linkedin/job-description.route.ts
@@ -2,7 +2,8 @@ import ErrorEventEndpoint from '../../../../services/EventEndpoint/ErrorEventEnd
 import { EventEndpoint } from '../../../../services';
 import service from '../../../virtual-browser.service';
 
-const LOGIN_MODAL_CLOSE_BUTTON_SELECTOR = '#base-contextual-sign-in-modal .contextual-sign-in-modal__modal-dismiss';
+const LOGIN_MODAL_SELECTOR = '#base-contextual-sign-in-modal';
+const LOGIN_MODAL_CLOSE_BUTTON_SELECTOR = `${LOGIN_MODAL_SELECTOR} .contextual-sign-in-modal__modal-dismiss`;
 const SHOW_MORE_BUTTON_SELECTOR = '.show-more-less-html__button';
 const JOB_DESCRIPTION_SELECTOR = '.description__text';
 
@@ -19,10 +20,11 @@ export default new EventEndpoint({
       try {
          const page = await service.newPage(pageName, jobURL);
 
-         try {
+         const loginModal = await page.getElement(LOGIN_MODAL_SELECTOR);
+         const isLoginModalVisible = await loginModal?.isVisible();
+
+         if (isLoginModalVisible) {
             await page.click(LOGIN_MODAL_CLOSE_BUTTON_SELECTOR);
-         } catch {
-            // Continue any way because sometimes the login modal does not appear
          }
 
          // Clicking on the "see more" button

--- a/src/services/VirtualBrowser/VirtualBrowserPage.ts
+++ b/src/services/VirtualBrowser/VirtualBrowserPage.ts
@@ -152,7 +152,7 @@ class VirtualBrowserPage {
 
    }
 
-   async getElement(selector: string) {
+   async getElement(selector: string, waitForVisible: boolean = false): Promise<null | import('puppeteer').ElementHandle> {
       if (!this._page) {
          throw new ErrorVirtualBrowser('Page not initialized', 'PAGE_NOT_INITIALIZED');
       }
@@ -162,7 +162,10 @@ class VirtualBrowserPage {
       }
 
       try {
-         await this._page.waitForSelector(selector, { visible: true });
+         if (waitForVisible) {
+            await this._page.waitForSelector(selector, { visible: true });
+         }
+
          return await this._page.$(selector);
       } catch (error: any) {
          throw new ErrorVirtualBrowser(error.message, error.code || 'PAGE_GET_ELEMENT_ERROR');


### PR DESCRIPTION
## [FRCV-128] Description
Added real-time status updates to the custom CV summary generation process, including 'fetching-url', 'generating-summary', 'success', and 'error' states. Enhanced LinkedIn job description scraping by explicitly checking for and closing the login modal if visible. Updated VirtualBrowserPage.getElement to optionally wait for element visibility.

[FRCV-128]: https://feliperamosdev.atlassian.net/browse/FRCV-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ