### PR TITLE
[FRCV-130] Fix for issue of missing fields on CV creating

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -104,6 +104,7 @@ export default class CV extends CVSet {
       return {
          title: this.title,
          notes: this.notes,
+         experience_time: this.experience_time,
          is_master: this.is_master,
          cv_owner_id: this.cv_owner_id,
          cv_experiences: this.cv_experiences,

--- a/src/routes/curriculum/create.route.ts
+++ b/src/routes/curriculum/create.route.ts
@@ -10,7 +10,19 @@ export default new Route({
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],
    controller: async (req: Request, res: Response) => {
-      const { title, notes, cv_experiences = [], cv_skills = [], summary, is_master, job_title, sub_title, experience_time }: CVSetup = req.body;
+      const {
+         title,
+         notes,
+         cv_experiences = [],
+         cv_educations = [],
+         cv_languages = [],
+         cv_skills = [],
+         summary,
+         is_master,
+         job_title,
+         sub_title,
+         experience_time
+      }: CVSetup = req.body;
       const userId = req.session?.user?.id;
 
       if (!userId) {
@@ -29,6 +41,8 @@ export default new Route({
             notes,
             experience_time,
             cv_experiences,
+            cv_educations,
+            cv_languages,
             cv_skills,
             summary,
             job_title,


### PR DESCRIPTION
## [FRCV-130] Description
This pull request extends the curriculum creation functionality by supporting additional fields for educations and languages, and ensures the new `experience_time` field is included throughout the data flow. The changes affect both the model and the route handling curriculum creation.

**Curriculum creation enhancements:**

* The curriculum creation route now accepts `cv_educations` and `cv_languages` arrays in addition to existing fields, allowing users to include education and language information when creating a CV. [[1]](diffhunk://#diff-50e0775b496610b4f2821aa5dc2ba10c1683fdca77c8d724141bc1c30e3c4dd5L13-R25) [[2]](diffhunk://#diff-50e0775b496610b4f2821aa5dc2ba10c1683fdca77c8d724141bc1c30e3c4dd5R44-R45)
* The `experience_time` field is now included in the CV model's serialization, ensuring it is saved and returned as part of the curriculum data.

These changes improve the flexibility and completeness of the curriculum data model and API.