### PR TITLE
[FRCV-131] Favorites CV Feature

### DIFF
--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -15,6 +15,7 @@ export default class CV extends CVSet {
    public title: string;
    public experience_time: number | null;
    public is_master: boolean;
+   public is_favorite: boolean;
    public notes?: string;
    public cv_experiences?: (Experience | number)[];
    public cv_skills?: (Skill | number)[];
@@ -27,6 +28,7 @@ export default class CV extends CVSet {
       'cvs.id',
       'title',
       'is_master',
+      'is_favorite',
       'experience_time',
       'notes',
       'cv_experiences',
@@ -42,6 +44,7 @@ export default class CV extends CVSet {
          title = '',
          experience_time = 0,
          is_master = false,
+         is_favorite = false,
          notes = '',
          cv_owner_id,
          user_id,
@@ -55,6 +58,7 @@ export default class CV extends CVSet {
       this.title = title;
       this.experience_time = experience_time;
       this.is_master = Boolean(is_master);
+      this.is_favorite = Boolean(is_favorite);
       this.notes = notes;
       this.languageSets = languageSets;
       this.cv_owner_id = cv_owner_id || user_id;
@@ -106,6 +110,7 @@ export default class CV extends CVSet {
          notes: this.notes,
          experience_time: this.experience_time,
          is_master: this.is_master,
+         is_favorite: this.is_favorite,
          cv_owner_id: this.cv_owner_id,
          cv_experiences: this.cv_experiences,
          cv_skills: this.cv_skills,

--- a/src/database/models/curriculums_schema/CV/CV.types.ts
+++ b/src/database/models/curriculums_schema/CV/CV.types.ts
@@ -9,6 +9,7 @@ export interface CVSetup extends CVSetSetup {
    title: string;
    experience_time?: number;
    is_master?: boolean;
+   is_favorite?: boolean;
    notes?: string;
    cv_experiences?: (ExperienceSetup | number)[];
    cv_skills?: (SkillSetup | number)[];

--- a/src/database/tables/curriculums_schema/cvs.ts
+++ b/src/database/tables/curriculums_schema/cvs.ts
@@ -12,6 +12,7 @@ export default new Table({
       { name: 'title', type: 'VARCHAR(255)', notNull: true },
       { name: 'experience_time', type: 'DECIMAL(2,1)' },
       { name: 'is_master', type: 'BOOLEAN', defaultValue: false },
+      { name: 'is_favorite', type: 'BOOLEAN', defaultValue: false },
       { name: 'notes', type: 'TEXT' },
       { name: 'cv_experiences', type: 'INTEGER[]' },
       { name: 'cv_skills', type: 'INTEGER[]' },


### PR DESCRIPTION
## [FRCV-131] Description
This pull request adds support for marking a CV as a favorite throughout the backend model, type definitions, and database schema. The main change is the introduction of the new boolean property `is_favorite` to the CV entity, ensuring it is consistently handled in model logic, type interfaces, and database storage.

**Model and Type Updates:**
- Added the `is_favorite` property to the `CV` class, including its constructor, serialization method, and property list, ensuring it is treated as a boolean and included in relevant operations. [[1]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR18) [[2]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR47) [[3]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR61) [[4]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR113) [[5]](diffhunk://#diff-8d9e17cba23eee20defc8478707a1d4514ea5424668400724408c2d7442b7c2cR31)
- Updated the `CVSetup` interface to include the optional `is_favorite` property, allowing it to be set during CV creation or update.

**Database Schema Update:**
- Modified the `cvs` table definition to add the `is_favorite` boolean column with a default value of `false`.

[FRCV-131]: https://feliperamosdev.atlassian.net/browse/FRCV-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ