### PR TITLE
[FRCV-134] CV Favorites Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,19 +578,19 @@ services:
 ### Curriculum/CV Management (Protected Routes)
 - `POST /curriculum/create` - Create new CV/resume (Admin/Master)
 - `POST /curriculum/create-set` - Create CV language set (Admin/Master)
-- `GET /curriculum/user-cvs` - Get user's CVs (Admin/Master)
 - `GET /curriculum/:cv_id` - Get CV details by ID (Admin/Master)
 - `POST /curriculum/update` - Update CV information (Admin/Master)
 - `POST /curriculum/update-set` - Update CV language set (Admin/Master)
 - `POST /curriculum/set-master` - Set CV as master/primary CV (Admin/Master)
 - `DELETE /curriculum/delete` - Delete CV (Admin/Master)
 - `GET /curriculum/public/:cv_id` - Get public CV data for display
-- `GET /user/master-cv` - Get master user's primary CV
 
 ### User Management (Protected Routes)
 - `POST /user/update` - Update user profile information (Admin/Master)
 - `GET /user/languages` - Get user's language skills (Admin/Master)
 - `GET /user/educations` - Get user's education records (Admin/Master)
+- `GET /user/master-cv` - Get master user's primary CV
+- `GET /user/cvs` - Get user's CVs (Admin/Master)
 
 ### AI & System Routes
 - `POST /assistant-generate` - Generate AI responses

--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -44,7 +44,6 @@ import curriculumCreateSet from '../routes/curriculum/create-set.route';
 import curriculumGet from '../routes/curriculum/cv_id.route';
 import curriculumUpdate from '../routes/curriculum/update.route';
 import curriculumUpdateSet from '../routes/curriculum/update-set.route';
-import curriculumUserCVs from '../routes/curriculum/user-cvs.route';
 import curriculumSetMaster from '../routes/curriculum/set-master.route';
 import curriculumDelete from '../routes/curriculum/delete.route';
 import curriculumPublicGet from '../routes/curriculum/public/cv_id.route';
@@ -59,6 +58,7 @@ import userUpdate from '../routes/user/update.route';
 import userMasterCV from '../routes/user/master-cv.route';
 import userLanguages from '../routes/user/languages.route';
 import userEducations from '../routes/user/educations.route';
+import userCVs from '../routes/user/cvs.route';
 
 const SERVER_API_PORT = Number(process.env.SERVER_API_PORT || 8000);
 const CORS_ORIGIN = process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.replace(/ /g, '').split(',') : undefined;
@@ -130,7 +130,6 @@ global.service = new ServerAPI({
       curriculumCreateSet,
       curriculumUpdate,
       curriculumUpdateSet,
-      curriculumUserCVs,
       curriculumGet,
       curriculumSetMaster,
       curriculumDelete,
@@ -143,7 +142,8 @@ global.service = new ServerAPI({
       userUpdate,
       userMasterCV,
       userLanguages,
-      userEducations
+      userEducations,
+      userCVs
    ],
    onListen: function () {
       console.log(`Server API is running on port ${this.PORT}`);

--- a/src/database/models/curriculums_schema/CV/CV.ts
+++ b/src/database/models/curriculums_schema/CV/CV.ts
@@ -264,7 +264,7 @@ export default class CV extends CVSet {
          }
 
          const user_id = user.id;
-         const [masterCV] = await this.getUserCVs(user_id, language_set, true);
+         const [masterCV] = await this.getUserCVs(user_id, { language_set, is_master: true });
 
          if (!masterCV) {
             return null;
@@ -276,16 +276,22 @@ export default class CV extends CVSet {
       }
    }
 
-   static async getUserCVs(user_id: number, language_set: string = defaultLocale, onlyMaster?: boolean): Promise<CV[]> {
+   static async getUserCVs(user_id: number, customWhere: Partial<CV> = {}): Promise<CV[]> {
+      const { language_set = defaultLocale, is_favorite, is_master } = customWhere;
+
       try {
          const getQuery = database.select('curriculums_schema', 'cv_sets');
+         const where: Partial<CV> = { user_id, language_set };
 
-         if (onlyMaster) {
-            getQuery.where({ user_id, language_set, is_master: true });
-         } else {
-            getQuery.where({ user_id, language_set });
+         if (is_master) {
+            where.is_master = true;
+         }
+         
+         if (is_favorite !== undefined) {
+            where.is_favorite = is_favorite;
          }
 
+         getQuery.where(where);
          getQuery.populate('cv_id', this.populateFields);
          const { data = [], error } = await getQuery.exec();
 

--- a/src/routes/user/cvs.route.ts
+++ b/src/routes/user/cvs.route.ts
@@ -5,12 +5,12 @@ import CV from '../../database/models/curriculums_schema/CV/CV';
 
 export default new Route({
    method: 'GET',
-   routePath: '/curriculum/user-cvs',
+   routePath: '/user/cvs',
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],
    controller: async (req: Request, res: Response) => {
       const userId = req.session?.user?.id;
-      const { language_set } = req.query;
+      const { language_set, is_favorite } = req.query;
 
       if (!userId) {
          new ErrorResponseServerAPI('User ID is required', 400, 'USER_ID_REQUIRED').send(res);
@@ -18,7 +18,10 @@ export default new Route({
       }
 
       try {
-         const cvs = await CV.getUserCVs(userId, language_set as string);
+         const cvs = await CV.getUserCVs(userId, {
+            language_set: language_set as string,
+            is_favorite: is_favorite !== undefined ? Boolean(is_favorite) : undefined
+         });
 
          if (!cvs) {
             new ErrorResponseServerAPI('No CVs found for this user', 404, 'CVS_NOT_FOUND').send(res);


### PR DESCRIPTION
## [FRCV-134] Description
This pull request refactors how user CVs are fetched and exposes a more flexible API endpoint for retrieving them. The main improvements are the consolidation and enhancement of the user CV retrieval logic, as well as updates to the API routes and documentation.

**API Route Refactoring and Enhancement:**

* The old `GET /curriculum/user-cvs` endpoint has been replaced with a new `GET /user/cvs` endpoint, making the route more logically grouped under user-related actions. The new endpoint also supports filtering by `is_favorite` in addition to `language_set`. [[1]](diffhunk://#diff-9e603c60ce04cee25b514fa380d902c9c29a3cb7142bd8d9d541d1c008351017L8-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L581-R593) [[3]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL47) [[4]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR61) [[5]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL133) [[6]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bL146-R146)

**Backend Logic Improvements:**

* The `CV.getUserCVs` method has been refactored to accept a flexible filter object (`customWhere`) instead of positional arguments, allowing for easier extension and more robust querying (e.g., filtering by `is_master`, `is_favorite`, and `language_set`).
* Calls to `getUserCVs` throughout the codebase have been updated to use the new filter object, improving clarity and maintainability.

**Documentation Updates:**

* The API documentation in `README.md` has been updated to reflect the new and changed endpoints, ensuring users and developers have accurate reference material.