### PR TITLE
[FRCV-138] Opportunities Schema/Table/Model

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -7,6 +7,7 @@ import users_schema from './schemas/users_schema';
 import curriculums_schema from './schemas/curriculums_schema';
 import languages_schema from './schemas/languages_schema';
 import educations_schema from './schemas/educations_schema';
+import opportunities_schema from './schemas/opportunities_schema';
 
 const database = new PostgresDB({
    dbName: process.env.POSTGRES_DB,
@@ -21,7 +22,8 @@ const database = new PostgresDB({
       experiences_schema,
       languages_schema,
       curriculums_schema,
-      educations_schema
+      educations_schema,
+      opportunities_schema
    ]
 });
 

--- a/src/database/models/opportunities_schema/Opportunity/Opportunity.ts
+++ b/src/database/models/opportunities_schema/Opportunity/Opportunity.ts
@@ -1,0 +1,54 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { OpportunitySetup } from './Opportunity.types';
+import { CV } from '../../curriculums_schema';
+import { Company } from '../../companies_schema';
+
+export default class Opportunity extends TableRow {
+   public start_date: Date;
+   public end_date: Date;
+   public job_title: string;
+   public job_description: string;
+   public location: string;
+   public seniority_level: string;
+   public employment_type: string;
+   public cv_id: number;
+   public company_id: number;
+   public relatedCV?: CV;
+   public company?: Company;
+
+   constructor (setup: OpportunitySetup) {
+      super('opportunities_schema', 'opportunities', setup);
+
+      const {
+         start_date,
+         end_date,
+         job_title,
+         job_description,
+         location,
+         seniority_level,
+         employment_type,
+         cv_id,
+         company_id,
+         relatedCV,
+         company
+      } = setup || {};
+
+      this.start_date = start_date;
+      this.end_date = end_date;
+      this.job_title = job_title;
+      this.job_description = job_description;
+      this.location = location;
+      this.seniority_level = seniority_level;
+      this.employment_type = employment_type;
+      this.cv_id = cv_id;
+      this.company_id = company_id;
+
+      if (relatedCV) {
+         this.relatedCV = new CV(relatedCV);
+      }
+
+      if (company) {
+         this.company = new Company(company);
+      }
+   }
+}

--- a/src/database/models/opportunities_schema/Opportunity/Opportunity.types.ts
+++ b/src/database/models/opportunities_schema/Opportunity/Opportunity.types.ts
@@ -1,0 +1,19 @@
+import { CompanySetup } from '../../companies_schema/Company/Company.types';
+import { CVSetup } from '../../curriculums_schema/CV/CV.types';
+
+export interface OpportunitySetup {
+   id: number;
+   created_at: Date;
+   updated_at: Date;
+   start_date: Date;
+   end_date: Date;
+   job_title: string;
+   job_description: string;
+   location: string;
+   seniority_level: string;
+   employment_type: string;
+   cv_id: number;
+   company_id: number;
+   relatedCV?: CVSetup;
+   company?: CompanySetup;
+}

--- a/src/database/models/opportunities_schema/index.ts
+++ b/src/database/models/opportunities_schema/index.ts
@@ -1,0 +1,1 @@
+export { default as Opportunity } from './Opportunity/Opportunity';

--- a/src/database/schemas/opportunities_schema.ts
+++ b/src/database/schemas/opportunities_schema.ts
@@ -1,0 +1,7 @@
+import Schema from '../../services/Database/models/Schema';
+import opportunities from '../tables/opportunities_schema/opportunities';
+
+export default new Schema({
+   name: 'opportunities_schema',
+   tables: [ opportunities ]
+});

--- a/src/database/tables/opportunities_schema/opportunities.ts
+++ b/src/database/tables/opportunities_schema/opportunities.ts
@@ -1,0 +1,35 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'opportunities',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'start_date', type: 'DATE' },
+      { name: 'end_date', type: 'DATE' },
+      { name: 'job_title', type: 'VARCHAR(255)' },
+      { name: 'job_description', type: 'TEXT' },
+      { name: 'location', type: 'VARCHAR(255)' },
+      { name: 'seniority_level', type: 'VARCHAR(255)' },
+      { name: 'employment_type', type: 'VARCHAR(255)' },
+      {
+         name: 'cv_id',
+         type: 'INTEGER',
+         relatedField: {
+            schema: 'curriculums_schema',
+            table: 'cvs',
+            field: 'id'
+         }
+      },
+      {
+         name: 'company_id',
+         type: 'INTEGER',
+         relatedField: {
+            schema: 'companies_schema',
+            table: 'companies',
+            field: 'id'
+         }
+      }
+   ]
+});


### PR DESCRIPTION
## [FRCV-138] Description
This pull request introduces a new `opportunities_schema` to the database, adding support for managing job opportunities and their relationships to CVs and companies. The changes include new schema, table, and model definitions, as well as updates to the database initialization to register the new schema.

**Database schema and registration:**

* Added `opportunities_schema` to the database initialization in `src/database/index.ts`, ensuring it is loaded alongside other schemas. [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R10) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352L24-R26)
* Created `src/database/schemas/opportunities_schema.ts` to define the new schema and register its tables.

**Table and model definitions:**

* Defined the `opportunities` table in `src/database/tables/opportunities_schema/opportunities.ts`, including fields for job details and foreign key relationships to CVs and companies.
* Implemented the `Opportunity` model in `src/database/models/opportunities_schema/Opportunity/Opportunity.ts`, with properties for all opportunity fields and logic to instantiate related CV and company objects.
* Added the `OpportunitySetup` type in `src/database/models/opportunities_schema/Opportunity/Opportunity.types.ts` to specify the shape of opportunity data, including optional related CV and company data.
* Exported the new `Opportunity` model from the schema index in `src/database/models/opportunities_schema/index.ts`.

[FRCV-138]: https://feliperamosdev.atlassian.net/browse/FRCV-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ