### PR TITLE
[FRCV-141] Comments Schema/Table/Model

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -9,6 +9,7 @@ import languages_schema from './schemas/languages_schema';
 import educations_schema from './schemas/educations_schema';
 import opportunities_schema from './schemas/opportunities_schema';
 import letters_schemas from './schemas/letters_schemas';
+import comments_schemas from './schemas/comments_schemas';
 
 const database = new PostgresDB({
    dbName: process.env.POSTGRES_DB,
@@ -25,7 +26,8 @@ const database = new PostgresDB({
       curriculums_schema,
       educations_schema,
       opportunities_schema,
-      letters_schemas
+      letters_schemas,
+      comments_schemas
    ]
 });
 

--- a/src/database/models/comments_schemas/Comment/Comment.ts
+++ b/src/database/models/comments_schemas/Comment/Comment.ts
@@ -1,0 +1,15 @@
+import TableRow from '../../../../services/Database/models/TableRow';
+import { CommentSetup } from './Comment.types';
+
+export default class Comment extends TableRow {
+   public content: string;
+   public author_id: number;
+
+   constructor (setup: CommentSetup) {
+      super('comments_schema', 'comments', setup);
+      const { content, author_id } = setup;
+
+      this.content = content;
+      this.author_id = author_id;
+   }
+}

--- a/src/database/models/comments_schemas/Comment/Comment.types.ts
+++ b/src/database/models/comments_schemas/Comment/Comment.types.ts
@@ -1,0 +1,4 @@
+export interface CommentSetup {
+   content: string;
+   author_id: number;
+}

--- a/src/database/models/comments_schemas/index.ts
+++ b/src/database/models/comments_schemas/index.ts
@@ -1,0 +1,1 @@
+export { default as Comment } from './Comment/Comment';

--- a/src/database/schemas/comments_schemas.ts
+++ b/src/database/schemas/comments_schemas.ts
@@ -1,0 +1,7 @@
+import Schema from '../../services/Database/models/Schema';
+import comments from '../tables/comments_schemas/comments';
+
+export default new Schema({
+   name: 'comments_schemas',
+   tables: [ comments ]
+});

--- a/src/database/tables/comments_schemas/comments.ts
+++ b/src/database/tables/comments_schemas/comments.ts
@@ -1,0 +1,21 @@
+import Table from '../../../services/Database/models/Table';
+
+export default new Table({
+   name: 'comments',
+   fields: [
+      { name: 'id', primaryKey: true, autoIncrement: true },
+      { name: 'created_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'updated_at', type: 'TIMESTAMP', defaultValue: 'CURRENT_TIMESTAMP' },
+      { name: 'content', type: 'TEXT', notNull: true },
+      {
+         name: 'author_id',
+         type: 'INTEGER',
+         relatedField: {
+            schema: 'users_schema',
+            table: 'admin_users',
+            field: 'id'
+         }
+      }
+   ]
+});
+


### PR DESCRIPTION
## [FRCV-141] Description
This pull request introduces a new comments schema and related model to the database layer, enabling support for storing and managing comments in the application. The main changes include the creation of the `comments_schemas` schema, its registration in the database, and the implementation of the `Comment` model.

**Database schema and model additions:**

* Added a new `comments_schemas` schema with a `comments` table, including fields for `id`, `created_at`, `updated_at`, `content`, and a foreign key `author_id` referencing `admin_users` in the `users_schema`. [[1]](diffhunk://#diff-cf6e7e223973461937799b9db142c1e7e7fa9ec6f81faf73643795c55865d5f1R1-R7) [[2]](diffhunk://#diff-f9508c1a56d2b4b49257d4c21ac15c375ec6f284c105b24fe15c30b63ea4caabR1-R21)
* Implemented the `Comment` model in `Comment.ts` and its associated type definition in `Comment.types.ts`, allowing for type-safe creation and manipulation of comment records. [[1]](diffhunk://#diff-3c7877c530f5381c480673034f0b6aa06a018991b65cdedf7ee42533ab29d0e2R1-R15) [[2]](diffhunk://#diff-e0a52311e0b4dc087bd659426a820780dea38d5d493a1f1fe69a0f51fada6ba1R1-R4)
* Exported the `Comment` model from the `comments_schemas` models index for use elsewhere in the application.

**Integration with database initialization:**

* Registered the new `comments_schemas` in the main database initialization file (`src/database/index.ts`) so that it is included when the database is set up. [[1]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352R12) [[2]](diffhunk://#diff-420267b413b2c82d72d778e81ae2a5151a1bd5c64449fd2d3c46894fb73ec352L28-R30)

[FRCV-141]: https://feliperamosdev.atlassian.net/browse/FRCV-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ