### PR TITLE
[FRCV-140] Fix the bad HTTP method standards

### DIFF
--- a/src/routes/company/delete.route.ts
+++ b/src/routes/company/delete.route.ts
@@ -3,12 +3,12 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'DELETE',
    routePath: '/company/delete',
    useAuth: true,
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
-      const { companyId } = req.body;
+      const { companyId } = req.query;
 
       if (!companyId) {
          new ErrorResponseServerAPI('Company ID is required', 400, 'ERROR_COMPANY_ID_REQUIRED').send(res);
@@ -16,7 +16,7 @@ export default new Route({
       }
 
       try {
-         const deleted = await Company.delete(companyId);
+         const deleted = await Company.delete(Number(companyId));
 
          if (!deleted) {
             new ErrorResponseServerAPI('Company not found or could not be deleted', 404, 'ERROR_COMPANY_NOT_FOUND').send(res);

--- a/src/routes/company/delete.route.ts
+++ b/src/routes/company/delete.route.ts
@@ -9,14 +9,15 @@ export default new Route({
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
       const { companyId } = req.query;
+      const companyIdNumber = Number(companyId);
 
-      if (!companyId) {
+      if (!companyIdNumber || isNaN(companyIdNumber)) {
          new ErrorResponseServerAPI('Company ID is required', 400, 'ERROR_COMPANY_ID_REQUIRED').send(res);
          return;
       }
 
       try {
-         const deleted = await Company.delete(Number(companyId));
+         const deleted = await Company.delete(companyIdNumber);
 
          if (!deleted) {
             new ErrorResponseServerAPI('Company not found or could not be deleted', 404, 'ERROR_COMPANY_NOT_FOUND').send(res);

--- a/src/routes/company/update-set.route.ts
+++ b/src/routes/company/update-set.route.ts
@@ -4,7 +4,7 @@ import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorRespons
 import { Request, Response } from 'express';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/company/update-set',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/company/update.route.ts
+++ b/src/routes/company/update.route.ts
@@ -3,7 +3,7 @@ import { Route } from "../../services";
 import ErrorResponseServerAPI from "../../services/ServerAPI/models/ErrorResponseServerAPI";
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/company/update',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/curriculum/delete.route.ts
+++ b/src/routes/curriculum/delete.route.ts
@@ -9,14 +9,15 @@ export default new Route({
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
       const { cvId } = req.query;
+      const cvIdNumber = Number(cvId);
 
-      if (!cvId) {
+      if (!cvIdNumber || isNaN(cvIdNumber)) {
          new ErrorResponseServerAPI('CV ID is required', 400, 'ERROR_CV_ID_REQUIRED').send(res);
          return;
       }
 
       try {
-         const deleted = await CV.delete(Number(cvId));
+         const deleted = await CV.delete(cvIdNumber);
 
          if (!deleted) {
             new ErrorResponseServerAPI('CV not found or could not be deleted', 404, 'ERROR_CV_NOT_FOUND').send(res);

--- a/src/routes/curriculum/delete.route.ts
+++ b/src/routes/curriculum/delete.route.ts
@@ -3,12 +3,12 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'DELETE',
    routePath: '/curriculum/delete',
    useAuth: true,
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
-      const { cvId } = req.body;
+      const { cvId } = req.query;
 
       if (!cvId) {
          new ErrorResponseServerAPI('CV ID is required', 400, 'ERROR_CV_ID_REQUIRED').send(res);
@@ -16,7 +16,7 @@ export default new Route({
       }
 
       try {
-         const deleted = await CV.delete(cvId);
+         const deleted = await CV.delete(Number(cvId));
 
          if (!deleted) {
             new ErrorResponseServerAPI('CV not found or could not be deleted', 404, 'ERROR_CV_NOT_FOUND').send(res);

--- a/src/routes/curriculum/set-master.route.ts
+++ b/src/routes/curriculum/set-master.route.ts
@@ -1,9 +1,9 @@
-import CV from "../../database/models/curriculums_schema/CV/CV";
-import { Route } from "../../services";
-import ErrorResponseServerAPI from "../../services/ServerAPI/models/ErrorResponseServerAPI";
+import CV from '../../database/models/curriculums_schema/CV/CV';
+import { Route } from '../../services';
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/curriculum/set-master',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/curriculum/update-set.route.ts
+++ b/src/routes/curriculum/update-set.route.ts
@@ -3,7 +3,7 @@ import { Route } from '../../services';
 import CVSet from '../../database/models/curriculums_schema/CVSet/CVSet';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/curriculum/update-set',
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],

--- a/src/routes/curriculum/update.route.ts
+++ b/src/routes/curriculum/update.route.ts
@@ -3,7 +3,7 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/curriculum/update',
    useAuth: true,
    allowedRoles: [ 'admin', 'master' ],

--- a/src/routes/experience/delete.route.ts
+++ b/src/routes/experience/delete.route.ts
@@ -3,12 +3,12 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'DELETE',
    routePath: '/experience/delete',
    useAuth: true,
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
-      const { experienceId } = req.body;
+      const { experienceId } = req.query;
 
       if (!experienceId) {
          new ErrorResponseServerAPI('Experience ID is required', 400, 'ERROR_EXPERIENCE_ID_REQUIRED').send(res);
@@ -16,8 +16,8 @@ export default new Route({
       }
 
       try {
-         const deleted = await Experience.delete(experienceId);
-         
+         const deleted = await Experience.delete(Number(experienceId));
+
          if (!deleted) {
             new ErrorResponseServerAPI('Experience not found or could not be deleted', 404, 'ERROR_EXPERIENCE_NOT_FOUND').send(res);
             return;

--- a/src/routes/experience/delete.route.ts
+++ b/src/routes/experience/delete.route.ts
@@ -9,14 +9,15 @@ export default new Route({
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
       const { experienceId } = req.query;
+      const experienceIdNumber = Number(experienceId);
 
-      if (!experienceId) {
+      if (!experienceIdNumber || isNaN(experienceIdNumber)) {
          new ErrorResponseServerAPI('Experience ID is required', 400, 'ERROR_EXPERIENCE_ID_REQUIRED').send(res);
          return;
       }
 
       try {
-         const deleted = await Experience.delete(Number(experienceId));
+         const deleted = await Experience.delete(experienceIdNumber);
 
          if (!deleted) {
             new ErrorResponseServerAPI('Experience not found or could not be deleted', 404, 'ERROR_EXPERIENCE_NOT_FOUND').send(res);

--- a/src/routes/experience/update-set.route.ts
+++ b/src/routes/experience/update-set.route.ts
@@ -3,7 +3,7 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/experience/update-set',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/experience/update.route.ts
+++ b/src/routes/experience/update.route.ts
@@ -4,7 +4,7 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/experience/update',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/skill/delete.route.ts
+++ b/src/routes/skill/delete.route.ts
@@ -9,14 +9,15 @@ export default new Route({
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
       const { skillId } = req.query;
+      const skillIdNumber = Number(skillId);
 
-      if (!skillId) {
+      if (!skillIdNumber || isNaN(skillIdNumber)) {
          new ErrorResponseServerAPI('Skill ID is required', 400, 'ERROR_SKILL_ID_REQUIRED').send(res);
          return;
       }
 
       try {
-         const deleted = await Skill.delete(Number(skillId));
+         const deleted = await Skill.delete(skillIdNumber);
 
          if (!deleted) {
             new ErrorResponseServerAPI('Skill not found or could not be deleted', 404, 'ERROR_SKILL_NOT_FOUND').send(res);

--- a/src/routes/skill/delete.route.ts
+++ b/src/routes/skill/delete.route.ts
@@ -3,12 +3,12 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'DELETE',
    routePath: '/skill/delete',
    useAuth: true,
    allowedRoles: ['admin', 'master'],
    controller: async (req, res) => {
-      const { skillId } = req.body;
+      const { skillId } = req.query;
 
       if (!skillId) {
          new ErrorResponseServerAPI('Skill ID is required', 400, 'ERROR_SKILL_ID_REQUIRED').send(res);
@@ -16,7 +16,7 @@ export default new Route({
       }
 
       try {
-         const deleted = await Skill.delete(skillId);
+         const deleted = await Skill.delete(Number(skillId));
 
          if (!deleted) {
             new ErrorResponseServerAPI('Skill not found or could not be deleted', 404, 'ERROR_SKILL_NOT_FOUND').send(res);

--- a/src/routes/skill/update-set.route.ts
+++ b/src/routes/skill/update-set.route.ts
@@ -4,7 +4,7 @@ import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorRespons
 import { Request, Response } from 'express';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/skill/update-set',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/skill/update.route.ts
+++ b/src/routes/skill/update.route.ts
@@ -4,7 +4,7 @@ import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorRespons
 import { Request, Response } from 'express';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/skill/update',
    useAuth: true,
    allowedRoles: ['admin', 'master'],

--- a/src/routes/user/update.route.ts
+++ b/src/routes/user/update.route.ts
@@ -3,7 +3,7 @@ import { Route } from '../../services';
 import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
 
 export default new Route({
-   method: 'POST',
+   method: 'PATCH',
    routePath: '/user/update',
    controller: async (req, res) => {
       const { updates } = req.body;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
       "skipLibCheck": true,
       "outDir": "dist",
       "target": "ES2020",
-      "module": "CommonJS",
-      "moduleResolution": "node",
+      "module": "Node16",
+      "moduleResolution": "node16",
       "esModuleInterop": true,
       "allowSyntheticDefaultImports": true,
       "resolveJsonModule": true,
@@ -29,7 +29,7 @@
       "transpileOnly": true,
       "files": true,
       "compilerOptions": {
-         "module": "CommonJS"
+         "module": "Node16"
       }
    },
    "include": ["*.ts", "*.service.ts", "*.route.ts", "src/**/*.ts"],


### PR DESCRIPTION
## [FRCV-140] Description
This pull request updates the HTTP methods for several API routes to better align with RESTful conventions. Most update routes now use `PATCH` instead of `POST`, and delete routes use `DELETE` instead of `POST`. Additionally, delete routes now expect resource IDs in the query parameters and ensure IDs are passed as numbers to the delete functions.

**HTTP Method Alignment and API Improvements**

_Update routes switched from `POST` to `PATCH`:_

* Changed the method from `POST` to `PATCH` for company, curriculum, experience, skill, and user update endpoints (`src/routes/company/update.route.ts`, `src/routes/company/update-set.route.ts`, `src/routes/curriculum/update.route.ts`, `src/routes/curriculum/update-set.route.ts`, `src/routes/curriculum/set-master.route.ts`, `src/routes/experience/update.route.ts`, `src/routes/experience/update-set.route.ts`, `src/routes/skill/update.route.ts`, `src/routes/skill/update-set.route.ts`, `src/routes/user/update.route.ts`). [[1]](diffhunk://#diff-d553f67691dcf87efdecae9e860744a8fe72dbec3bfaf7b6d0e5f873a1733f17L6-R6) [[2]](diffhunk://#diff-84de266279445d41ce444e07e1a37da01122d4b6901fe762aeaa688664cb52bdL7-R7) [[3]](diffhunk://#diff-0b6fd81a1c5ea3bfaa541ace065e4d0c04a96c6dcc8e8abb11563f4c63d6ad37L6-R6) [[4]](diffhunk://#diff-3900337d8dc76e1ebe0f7a6843ac5c2cc1a569d3105cff185ffdf27c8a108643L6-R6) [[5]](diffhunk://#diff-76b02f2433ac07037de6f238a49d9f71854ed15f000558de1c8f3992af3c43feL1-R6) [[6]](diffhunk://#diff-2efafad750918b2d83e05aa2e726d04c75c3f332715dfe4535d9519f88fc0568L7-R7) [[7]](diffhunk://#diff-dbcc19e37a269c2745db25c79750a313d051e2f138c805c840ad0ba507e85580L6-R6) [[8]](diffhunk://#diff-25f2991d35e06f211bd219bdda0c3380aafd8dd817c0291762264403caba9290L7-R7) [[9]](diffhunk://#diff-ffd903d94eb3c793763f93cb2b8fde5a91321b571a63663878212aa9e588bea8L7-R7) [[10]](diffhunk://#diff-7da161db06c975587cc8932eb28a3007aeb76c7f74023799650ff0864343aa2eL6-R6)

_Delete routes switched from `POST` to `DELETE` and refactored input handling:_

* Changed the method from `POST` to `DELETE` for company, curriculum, experience, and skill delete endpoints, and moved resource ID input from request body to query parameters, ensuring IDs are converted to numbers before deletion (`src/routes/company/delete.route.ts`, `src/routes/curriculum/delete.route.ts`, `src/routes/experience/delete.route.ts`, `src/routes/skill/delete.route.ts`). [[1]](diffhunk://#diff-6c50e136a6416ed56436ec91e0b2dd45b3655a61b01a1d9649d391cf3f167809L6-R19) [[2]](diffhunk://#diff-c440285e1f31e765bc8958143d839f43edaf3d30348a27d9ea334e206e789233L6-R19) [[3]](diffhunk://#diff-009d383748ef61ce2a998dc784069891c3923ce25839b45cb1ac73a020a8970bL6-R19) [[4]](diffhunk://#diff-56db9d13e269f0e4deecb65634e6c0358b1920755a4770f92b71182c87ac5eb2L6-R19)

[FRCV-140]: https://feliperamosdev.atlassian.net/browse/FRCV-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ