### PR TITLE
[FRCV-145] Scrape and Summary Status

### DIFF
--- a/src/containers/namespaces/opportunities/events/generate-summary.ts
+++ b/src/containers/namespaces/opportunities/events/generate-summary.ts
@@ -25,7 +25,7 @@ const generateSummaryEvent: NamespaceEvent = {
       }
 
       const generateSummary = async (room: SocketRoom, jobDescr: string, jobTitle?: string, jobCompany?: string) => {
-         this.sendToRoom(room.id, 'opportunities:status', 'generating-summary');
+         this.sendToRoom(room.id, 'opportunities:generate-summary:status', 'generating-summary');
 
          socketServer.sendTo('/ai/generate-cv-summary', {
             jobDescription: jobDescr,
@@ -35,7 +35,7 @@ const generateSummaryEvent: NamespaceEvent = {
          }, ({ error, message, summary, threadID }) => {
             if (error) {
                console.error('AI Error:', { error, message });
-               this.sendToRoom(room.id, 'opportunities:status', 'error');
+               this.sendToRoom(room.id, 'opportunities:generate-summary:status', 'error');
 
                return callback({
                   error: new ErrorSocketServer(
@@ -45,18 +45,18 @@ const generateSummaryEvent: NamespaceEvent = {
                });
             }
 
-            this.sendToRoom(room.id, 'opportunities:status', 'success');
+            this.sendToRoom(room.id, 'opportunities:generate-summary:status', 'success');
             callback({ summary, jobDescription: jobDescr, jobTitle, jobCompany, aiThread: threadID });
          });
       }
 
       const getJobDescriptionFromURL = (room: SocketRoom) => {
-         this.sendToRoom(room.id, 'opportunities:status', 'fetching-url');
+         this.sendToRoom(room.id, 'opportunities:generate-summary:status', 'fetching-url');
 
          socketServer.sendTo('/virtual-browser/linkedin/job-infos', { jobURL }, ({ error, message, jobTitle, jobCompany, jobDescription: jobDescr }) => {
             if (error) {
                console.error('Job Description Error:', { error, message });
-               this.sendToRoom(room.id, 'opportunities:status', 'error');
+               this.sendToRoom(room.id, 'opportunities:generate-summary:status', 'error');
 
                return callback({
                   error: new ErrorSocketServer(


### PR DESCRIPTION
## [FRCV-145] Description
This pull request updates the socket event names in the `generate-summary.ts` file to use a more specific namespace for status updates related to summary generation. This change helps clarify the source of status messages and prevents potential confusion with other opportunity-related status events.

**Event name updates:**

* All status messages sent via `this.sendToRoom` in `generateSummary` and `getJobDescriptionFromURL` are now under the `'opportunities:generate-summary:status'` event name instead of the more generic `'opportunities:status'`. [[1]](diffhunk://#diff-b31349a07a6999d1d00f90a4bc0308e8bc823e30397156074d6fab91d24dc6e4L28-R28) [[2]](diffhunk://#diff-b31349a07a6999d1d00f90a4bc0308e8bc823e30397156074d6fab91d24dc6e4L38-R38) [[3]](diffhunk://#diff-b31349a07a6999d1d00f90a4bc0308e8bc823e30397156074d6fab91d24dc6e4L48-R59)