### PR TITLE
[FRCV-147] Improving Letters Fields

### DIFF
--- a/src/database/models/letters_schema/Letter/Letter.ts
+++ b/src/database/models/letters_schema/Letter/Letter.ts
@@ -5,7 +5,7 @@ export default class Letter extends TableRow {
    public subject: string;
    public body: string;
    public from_id: number;
-   public to_id: number;
+   public company_id: number;
 
    constructor (setup: LetterSetup) {
       super('letters_schema', 'letters', setup);
@@ -14,16 +14,16 @@ export default class Letter extends TableRow {
          subject,
          body,
          from_id,
-         to_id
+         company_id
       } = setup || {};
 
-      if (subject == null || body == null || from_id == null || to_id == null) {
-         throw new Error('Missing required fields to create a Letter! Required params: subject, body, from_id, to_id');
+      if (subject == null || body == null || from_id == null || company_id == null) {
+         throw new Error('Missing required fields to create a Letter! Required params: subject, body, from_id, company_id');
       }
 
       this.subject = subject;
       this.body = body;
       this.from_id = from_id;
-      this.to_id = to_id;
+      this.company_id = company_id;
    }
 }

--- a/src/database/models/letters_schema/Letter/Letter.types.ts
+++ b/src/database/models/letters_schema/Letter/Letter.types.ts
@@ -5,5 +5,5 @@ export interface LetterSetup {
    subject: string;
    body: string;
    from_id: number;
-   to_id: number;
+   company_id: number;
 }

--- a/src/database/tables/letters_schema/letters.ts
+++ b/src/database/tables/letters_schema/letters.ts
@@ -18,7 +18,7 @@ export default new Table({
          }
       },
       {
-         name: 'to_id',
+         name: 'company_id',
          type: 'INTEGER',
          relatedField: {
             schema: 'companies_schema',


### PR DESCRIPTION
## [FRCV-147] Description
This pull request updates the schema and model for the `Letter` entity to replace the `to_id` field with `company_id`. This change ensures that letters are now associated with a company rather than a recipient user. The updates affect the TypeScript types, model class, and table schema definition.

**Schema and model updates:**

* Replaced the `to_id` field with `company_id` in the `Letter` model class, including the constructor and required fields validation (`src/database/models/letters_schema/Letter/Letter.ts`). [[1]](diffhunk://#diff-873ab8ba21ba4630d3fb6f1b52857cec304b03b377b3c01739f2762b4bde3626L8-R8) [[2]](diffhunk://#diff-873ab8ba21ba4630d3fb6f1b52857cec304b03b377b3c01739f2762b4bde3626L17-R27)
* Updated the `LetterSetup` interface to use `company_id` instead of `to_id` (`src/database/models/letters_schema/Letter/Letter.types.ts`).
* Changed the table schema definition to use `company_id` (with a relation to `companies_schema`) instead of `to_id` (`src/database/tables/letters_schema/letters.ts`).

[FRCV-147]: https://feliperamosdev.atlassian.net/browse/FRCV-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ