### PR TITLE
[FRCV-151] Delete Letter

### DIFF
--- a/src/containers/api-server.service.ts
+++ b/src/containers/api-server.service.ts
@@ -62,6 +62,7 @@ import opportunitiesDelete from '../routes/opportunity/delete.route';
 import letterCreate from '../routes/cover-letter/create.route';
 import letterSearch from '../routes/cover-letter/search.route';
 import letterUpdate from '../routes/cover-letter/update.route';
+import letterDelete from '../routes/cover-letter/delete.route';
 
 import userUpdate from '../routes/user/update.route';
 import userMasterCV from '../routes/user/master-cv.route';
@@ -163,6 +164,7 @@ global.service = new ServerAPI({
       letterCreate,
       letterSearch,
       letterUpdate,
+      letterDelete,
 
       userUpdate,
       userMasterCV,

--- a/src/database/models/letters_schema/Letter/Letter.ts
+++ b/src/database/models/letters_schema/Letter/Letter.ts
@@ -238,7 +238,7 @@ export default class Letter extends TableRow {
    }
 
    static async delete(id: number): Promise<Letter | null> {
-      if (!id || isNaN(Number(id))) {
+      if (!id || isNaN(id)) {
          throw new ErrorDatabase('Invalid Letter ID for delete!', 'INVALID_LETTER_ID');
       }
 

--- a/src/database/models/letters_schema/Letter/Letter.ts
+++ b/src/database/models/letters_schema/Letter/Letter.ts
@@ -23,7 +23,7 @@ export default class Letter extends TableRow {
    public company?: Company;
    public opportunity?: Opportunity;
 
-   constructor (setup: LetterSetup) {
+   constructor(setup: LetterSetup) {
       super('letters_schema', 'letters', setup);
 
       const {
@@ -52,7 +52,7 @@ export default class Letter extends TableRow {
       this.opportunity_id = opportunity_id;
       this.job_title = job_title;
       this.from_name = from_name;
-      
+
       if (from) {
          this.from = new AdminUser(from);
       }
@@ -91,7 +91,7 @@ export default class Letter extends TableRow {
    async populateCompany() {
       try {
          const { data = [], error } = await database.select('companies_schema', 'companies').where({ id: this.company_id }).exec();
-         const [ company ] = data;
+         const [company] = data;
 
          if (error) {
             throw new ErrorDatabase('Failed to populate company for Letter!', 'FAILED_TO_POPULATE_LETTER_COMPANY');
@@ -109,7 +109,7 @@ export default class Letter extends TableRow {
    async populateOpportunity() {
       try {
          const { data = [], error } = await database.select('opportunities_schema', 'opportunities').where({ id: this.opportunity_id }).exec();
-         const [ opportunity ] = data;
+         const [opportunity] = data;
 
          if (error) {
             throw new ErrorDatabase('Failed to populate opportunity for Letter!', 'FAILED_TO_POPULATE_LETTER_OPPORTUNITY');
@@ -127,7 +127,7 @@ export default class Letter extends TableRow {
    async populateUser() {
       try {
          const { data = [], error } = await database.select('users_schema', 'admin_users').where({ id: this.from_id }).exec();
-         const [ user ] = data;
+         const [user] = data;
 
          if (error) {
             throw new ErrorDatabase('Failed to populate user for Letter!', 'FAILED_TO_POPULATE_LETTER_USER');
@@ -144,7 +144,7 @@ export default class Letter extends TableRow {
    async save() {
       try {
          const { data = [], error } = await database.insert(this.schemaName, this.tableName).data(this.toSave).returning().exec();
-         const [ created ] = data;
+         const [created] = data;
 
          if (error) {
             throw new ErrorDatabase('Failed to save Letter to database!', 'FAILED_TO_SAVE_LETTER');
@@ -188,7 +188,7 @@ export default class Letter extends TableRow {
          }
 
          const { data = [], error } = await database.select('letters_schema', 'letters').where({ id }).exec();
-         const [ letter ] = data;
+         const [letter] = data;
 
          if (error) {
             throw new ErrorDatabase('Failed to fetch Letter from database!', 'FAILED_TO_FETCH_LETTER');
@@ -217,7 +217,7 @@ export default class Letter extends TableRow {
          }
 
          const { data: updatedData = [], error } = await database.update('letters_schema', 'letters').set(data).where({ id }).returning().exec();
-         const [ updated ] = updatedData;
+         const [updated] = updatedData;
          const letter = new Letter(updated);
 
          if (error) {
@@ -234,6 +234,29 @@ export default class Letter extends TableRow {
          return letter;
       } catch (error) {
          throw new ErrorDatabase('Failed to update Letter in database!', 'FAILED_TO_UPDATE_LETTER');
+      }
+   }
+
+   static async delete(id: number): Promise<Letter | null> {
+      if (!id || isNaN(Number(id))) {
+         throw new ErrorDatabase('Invalid Letter ID for delete!', 'INVALID_LETTER_ID');
+      }
+
+      try {
+         const { data = [], error } = await database.delete('letters_schema', 'letters').where({ id }).returning().exec();
+         const [deleted] = data;
+
+         if (error) {
+            throw new ErrorDatabase('Failed to delete Letter from database!', 'FAILED_TO_DELETE_LETTER');
+         }
+
+         if (!deleted) {
+            return null;
+         }
+
+         return new Letter(deleted);
+      } catch (error) {
+         throw new ErrorDatabase('Failed to delete Letter from database!', 'FAILED_TO_DELETE_LETTER');
       }
    }
 }

--- a/src/routes/cover-letter/delete.route.ts
+++ b/src/routes/cover-letter/delete.route.ts
@@ -29,7 +29,7 @@ export default new Route({
             return;
          }
 
-         res.status(204).send(deleted);
+         res.status(200).send(deleted);
       } catch (error) {
          new ErrorResponseServerAPI('Failed to delete cover letter', 500, 'ERROR_DELETING_COVER_LETTER').send(res);
          return;

--- a/src/routes/cover-letter/delete.route.ts
+++ b/src/routes/cover-letter/delete.route.ts
@@ -1,0 +1,38 @@
+import ErrorResponseServerAPI from '../../services/ServerAPI/models/ErrorResponseServerAPI';
+import { Route } from '../../services';
+import { Letter } from '../../database/models/letters_schema';
+
+export default new Route({
+   method: 'DELETE',
+   routePath: '/cover-letter/delete/:id',
+   useAuth: true,
+   allowedRoles: ['admin', 'master'],
+   async controller(req, res) {
+      const { id } = req.params;
+      const letterId = Number(id);
+
+      if (!id) {
+         new ErrorResponseServerAPI('Missing cover letter ID', 400, 'ERROR_MISSING_ID').send(res);
+         return;
+      }
+
+      if (isNaN(letterId)) {
+         new ErrorResponseServerAPI('Invalid cover letter ID', 400, 'ERROR_INVALID_ID').send(res);
+         return;
+      }
+
+      try {
+         const deleted = await Letter.delete(letterId);
+
+         if (!deleted) {
+            new ErrorResponseServerAPI('Cover letter not found', 404, 'ERROR_COVER_LETTER_NOT_FOUND').send(res);
+            return;
+         }
+
+         res.status(204).send(deleted);
+      } catch (error) {
+         new ErrorResponseServerAPI('Failed to delete cover letter', 500, 'ERROR_DELETING_COVER_LETTER').send(res);
+         return;
+      }
+   },
+});


### PR DESCRIPTION
## [FRCV-151] Description
This pull request adds support for deleting cover letters from the database via a new API route. The main changes include the implementation of the delete logic in the `Letter` model, the creation of the corresponding API endpoint, and integration of the new route into the server setup.

**Cover Letter Deletion Feature:**

* Added a new API route `DELETE /cover-letter/delete/:id` for deleting cover letters, including role-based access control and error handling. (`src/routes/cover-letter/delete.route.ts`)
* Implemented a static `delete` method in the `Letter` model to handle deletion logic and database interaction with appropriate error responses. (`src/database/models/letters_schema/Letter/Letter.ts`)

**Server Integration:**

* Registered the new `letterDelete` route in the API server setup to ensure the endpoint is available. (`src/containers/api-server.service.ts`) [[1]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR65) [[2]](diffhunk://#diff-d74a1473ab10e59381c28d71ae38097fd7afd5f8339828ee4d5492d64a4c9b6bR167)

[FRCV-151]: https://feliperamosdev.atlassian.net/browse/FRCV-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ