### PR TITLE
[FRCV-159] AICore Images Context

### DIFF
--- a/src/services/AICore/AICoreResponse.ts
+++ b/src/services/AICore/AICoreResponse.ts
@@ -3,7 +3,7 @@ import AICoreOutputCell from './models/AICoreOutputCell';
 import AICoreChat from './AICoreChat';
 import ErrorAICore from './ErrorAICore';
 import AICoreInputCell from './models/AICoreInputCell';
-import { ResponseCreateParamsNonStreaming, ResponseCreateParamsStreaming, ResponseOutputItem, ResponseOutputMessage } from 'openai/resources/responses/responses.mjs';
+import { ResponseCreateParamsNonStreaming, ResponseCreateParamsStreaming, ResponseOutputItem, ResponseOutputMessage } from 'openai/resources/responses/responses';
 import AIChatHistoryItem from './models/AIChatHistoryItem';
 
 export default class AICoreResponse {
@@ -71,7 +71,6 @@ export default class AICoreResponse {
       });
 
       this._input.push(cell);
-      // this.aiChat.newHistoryItem(cell);
       return cell;
    }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,7 +9,8 @@ export { default as AICore } from './AICore/AICore';
 export { default as SlackApp } from './SlackApp/SlackApp';
 export { default as Microservice } from './Microservice/Microservice';
 export { default as EventEndpoint } from './EventEndpoint/EventEndpoint';
+export { default as PostgresDB } from './Database/PostgresDB';
+
 export { ServerAPI } from './ServerAPI';
 export { Route } from './Route';
 export { SocketServer } from './SocketServer';
-export { default as PostgresDB } from './Database/PostgresDB';


### PR DESCRIPTION
## [FRCV-159] Description
This pull request introduces a new utility method for handling image input in the AI Core service and makes some minor improvements to module imports and code cleanup. The most significant change is the addition of the `attachImage` method to the `AICoreInputCell` class, which allows images to be attached either by URL or by reading a local file. Other changes include updating import paths for OpenAI response types and a minor code cleanup in the AI Core response logic.

### Image Input Handling

* Added a new `attachImage` method to the `AICoreInputCell` class in `src/services/AICore/models/AICoreInputCell.ts`, allowing images to be attached to input cells via URL or local file path, with error handling for invalid input or file read errors.

### Module Import Improvements

* Updated imports for OpenAI response types in both `src/services/AICore/models/AICoreInputCell.ts` and `src/services/AICore/AICoreResponse.ts` to use the correct path (`responses` instead of `responses.mjs`). [[1]](diffhunk://#diff-439cb54ca2f5d01449cbdc822de37be2449a61a83cac55eec5cf7859d5f72821L1-R1) [[2]](diffhunk://#diff-c1722c3500f64463eeeacc8e1767c95de07dbdbd4f2000a8fad57f5cd20e8abbL6-R6)

### Code Cleanup

* Removed commented-out code related to chat history in the `AICoreResponse` class to improve code clarity.
* Cleaned up the export order in `src/services/index.ts`, moving the `PostgresDB` export to the correct position.